### PR TITLE
Subject migration and url paths

### DIFF
--- a/custom/options/locale/locale_en-US.ini
+++ b/custom/options/locale/locale_en-US.ini
@@ -1048,6 +1048,7 @@ repo_name_auto_generated = Auto-generated from subject
 repo_subject = Subject name
 repo_subject_placeholder = E.g. Feminist Technology Studies, Climate Ethics
 repo_subject_helper = It should be short, clear and thematic.
+subject_cannot_be_modified = Subject cannot be modified after repository creation.
 repo_size = Repository Size
 template = Template
 template_select = Select a template.

--- a/custom/templates/base/head_navbar.tmpl
+++ b/custom/templates/base/head_navbar.tmpl
@@ -26,11 +26,11 @@
 					<a class="item{{if .PageIsMilestonesDashboard}} active{{end}}" href="{{AppSubUrl}}/milestones">{{ctx.Locale.Tr "milestones"}}</a>
 				{{end}}
 			{{end}}
-			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/articles">{{ctx.Locale.Tr "explore"}}</a>
+			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/subjects">{{ctx.Locale.Tr "explore"}}</a>
 		{{else if .IsLandingPageOrganizations}}
 			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/organizations">{{ctx.Locale.Tr "explore"}}</a>
 		{{else}}
-			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/articles">{{ctx.Locale.Tr "explore"}}</a>
+			<a class="item{{if .PageIsExplore}} active{{end}}" href="{{AppSubUrl}}/explore/subjects">{{ctx.Locale.Tr "explore"}}</a>
 		{{end}}
 
 		{{template "custom/extra_links" .}}

--- a/custom/templates/explore/navbar.tmpl
+++ b/custom/templates/explore/navbar.tmpl
@@ -1,5 +1,5 @@
 <overflow-menu class="ui secondary pointing menu tw-px-4">
-	<a class="{{if .PageIsExploreRepositories}}active {{end}}item" href="{{AppSubUrl}}/explore/articles">
+	<a class="{{if .PageIsExploreRepositories}}active {{end}}item" href="{{AppSubUrl}}/explore/subjects">
 		{{svg "octicon-goal"}} {{ctx.Locale.Tr "explore.repos"}}
 	</a>
 	{{if not .UsersPageIsDisabled}}

--- a/custom/templates/explore/repo_history.tmpl
+++ b/custom/templates/explore/repo_history.tmpl
@@ -25,7 +25,7 @@
                             {{if gt $node.Level 2}}<span class="ui basic mini label">{{svg "octicon-git-branch" 12}}</span><span class="ui basic mini label">{{svg "octicon-git-branch" 12}}</span><span class="ui basic mini label">{{svg "octicon-git-branch" 12}}</span>{{end}}
                         {{end}}
 
-                        <a class="ui large text" href="/explore/articles/history/{{$node.Repository.Name}}">
+                        <a class="ui large text" href="/subject/{{$node.Repository.GetSubject}}">
                             <strong>{{if $node.Repository.Owner}}{{$node.Repository.Owner.Name}}{{else}}unknown{{end}}/{{$node.Repository.Name}}</strong>
                         </a>
 

--- a/custom/templates/explore/repo_history.tmpl
+++ b/custom/templates/explore/repo_history.tmpl
@@ -311,15 +311,16 @@
                         {{end}}
                     </div>
                     {{/* Tab navigation for Read/Edit/History */}}
+                    {{/* Read/Edit/History should go under the url "%s/article/%s/%s" AppSubUrl .Repository.Owner.Name .Repository.GetSubject e.g. /article/wikipedia/Moon%20Landing */}}
                     <div class="tw-flex tw-items-center tw-gap-4">
                         <div class="ui top attached tabular menu tw-my-10 tw-gap-1">
-                            <a class="{{if .IsArticleModeRead}}active {{end}}item" href="{{QueryBuild (printf "%s/explore/articles/history/%s" AppSubUrl .Repository.Name) "view" "article" "mode" "read"}}">
+                            <a class="{{if .IsArticleModeRead}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "article" "mode" "read"}}">
                                 {{svg "octicon-book" 16}} Read
                             </a>
-                            <a class="{{if .IsArticleModeEdit}}active {{end}}item" href="{{QueryBuild (printf "%s/explore/articles/history/%s" AppSubUrl .Repository.Name) "view" "article" "mode" "edit"}}">
+                            <a class="{{if .IsArticleModeEdit}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "article" "mode" "edit"}}">
                                 {{svg "octicon-pencil" 16}} Edit
                             </a>
-                            <a class="{{if .IsArticleModeHistory}}active {{end}}item" href="{{QueryBuild (printf "%s/explore/articles/history/%s" AppSubUrl .Repository.Name) "view" "article" "mode" "history"}}">
+                            <a class="{{if .IsArticleModeHistory}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "article" "mode" "history"}}">
                                 {{svg "octicon-history" 16}} History
                             </a>
                             {{/* Align buttons on the right */}}

--- a/custom/templates/explore/subjects.tmpl
+++ b/custom/templates/explore/subjects.tmpl
@@ -1,0 +1,11 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content explore subjects">
+	<div class="ui container">
+		{{template "explore/navbar" .}}
+		{{template "shared/subject/search" .}}
+		{{template "shared/subject/list" .}}
+		{{template "base/paginate" .}}
+	</div>
+</div>
+{{template "base/footer" .}}
+

--- a/custom/templates/repo/header.tmpl
+++ b/custom/templates/repo/header.tmpl
@@ -12,13 +12,13 @@
 	<div class="ui container">
 		<overflow-menu class="ui secondary pointing menu">
 			<div class="overflow-menu-items tw-justify-center">
-				<a class="{{if .IsBubbleView}}active {{end}}item" href="{{QueryBuild (printf "%s/explore/articles/history/%s" AppSubUrl .Repository.Name) "view" "bubble"}}">
+				<a class="{{if .IsBubbleView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "bubble"}}">
 					{{svg "bubble"}} Bubble view
 				</a>
-				<a class="{{if .IsTableView}}active {{end}}item" href="{{QueryBuild (printf "%s/explore/articles/history/%s" AppSubUrl .Repository.Name) "view" "table"}}">
+				<a class="{{if .IsTableView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "table"}}">
 					{{svg "octicon-table"}} Table view
 				</a>
-				<a class="{{if .IsArticleView}}active {{end}}item" href="{{QueryBuild (printf "%s/explore/articles/history/%s" AppSubUrl .Repository.Name) "view" "article"}}">
+				<a class="{{if .IsArticleView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "article"}}">
 					{{svg "octicon-file"}} Article view
 				</a>
 			</div>

--- a/custom/templates/repo/search_name.tmpl
+++ b/custom/templates/repo/search_name.tmpl
@@ -1,1 +1,1 @@
-<span class="gt-ellipsis">{{.GetSubject}}{{if DefaultShowFullName}}<span class="search-fullname"> {{.FullName}}</span>{{end}}</span>
+<span class="gt-ellipsis">{{.Name}}{{if DefaultShowFullName}}<span class="search-fullname"> {{.FullName}}</span>{{end}}</span>

--- a/custom/templates/shared/subject/list.tmpl
+++ b/custom/templates/shared/subject/list.tmpl
@@ -1,0 +1,48 @@
+<div class="flex-list">
+	{{if .Keyword}}
+		<div class="tw-font-bold tw-text-base tw-mb-4">
+			{{ctx.Locale.Tr "explore.search_results_for" .Keyword}}
+		</div>
+	{{end}}
+	{{range .Subjects}}
+		<div class="flex-item">
+			<div class="flex-item-leading">
+				{{svg "octicon-book" 24}}
+			</div>
+			<div class="flex-item-main">
+				<div class="flex-item-header">
+					<div class="flex-item-title">
+						<a class="text primary name" href="/subject/{{PathEscapeSegments .Name}}">{{.Name}}</a>
+					</div>
+					<div class="flex-item-trailing muted-links">
+						{{if gt .RootRepoCount 0}}
+							<span class="flex-text-inline" data-tooltip-content="{{ctx.Locale.Tr "explore.subject.root_repositories"}}">
+								{{svg "octicon-repo" 16}}
+								<span>{{.RootRepoCount}}</span>
+							</span>
+						{{end}}
+						{{if gt .RepoCount .RootRepoCount}}
+							<span class="flex-text-inline" data-tooltip-content="{{ctx.Locale.Tr "explore.subject.total_repositories"}}">
+								{{svg "octicon-repo-forked" 16}}
+								<span>{{.RepoCount}}</span>
+							</span>
+						{{end}}
+					</div>
+				</div>
+				<div class="flex-item-body">
+					<span class="text small muted">
+						{{ctx.Locale.Tr "explore.subject.created"}} {{DateUtils.TimeSince .CreatedUnix}}
+						{{if ne .CreatedUnix .UpdatedUnix}}
+							· {{ctx.Locale.Tr "explore.subject.updated"}} {{DateUtils.TimeSince .UpdatedUnix}}
+						{{end}}
+					</span>
+				</div>
+			</div>
+		</div>
+	{{else}}
+		<div>
+			{{ctx.Locale.Tr "search.no_results"}}
+		</div>
+	{{end}}
+</div>
+

--- a/custom/templates/shared/subject/search.tmpl
+++ b/custom/templates/shared/subject/search.tmpl
@@ -1,0 +1,25 @@
+<div class="ui small secondary filter menu">
+	<form id="subject-search-form" class="ui form ignore-dirty tw-flex-1 tw-flex tw-items-center tw-gap-x-2">
+		<div class="ui small fluid action input tw-flex-1 tw-my-4">
+			{{template "shared/search/input" dict "Value" .Keyword "Placeholder" (ctx.Locale.Tr "search.subject_kind")}}
+			{{template "shared/search/button"}}
+		</div>
+		<!-- Sort -->
+		<div class="item ui small dropdown jump">
+			<div style="transform: rotate(90deg) !important;">
+				{{svg "octicon-arrow-switch" 14 "dropdown icon tw-mt-1 tw-rotate-90"}}
+			</div>
+			<span class="text">{{ctx.Locale.Tr "repo.issues.filter_sort"}}</span>
+			{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+			<div class="menu">
+				<label class="{{if eq .SortType "alphabetically"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "alphabetically"}}checked{{end}} value="alphabetically"> {{ctx.Locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</label>
+				<label class="{{if eq .SortType "reversealphabetically"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "reversealphabetically"}}checked{{end}} value="reversealphabetically"> {{ctx.Locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</label>
+				<label class="{{if eq .SortType "newest"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "newest"}}checked{{end}} value="newest"> {{ctx.Locale.Tr "repo.issues.filter_sort.latest"}}</label>
+				<label class="{{if eq .SortType "oldest"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "oldest"}}checked{{end}} value="oldest"> {{ctx.Locale.Tr "repo.issues.filter_sort.oldest"}}</label>
+				<label class="{{if eq .SortType "recentupdate"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "recentupdate"}}checked{{end}} value="recentupdate"> {{ctx.Locale.Tr "repo.issues.filter_sort.recentupdate"}}</label>
+				<label class="{{if eq .SortType "leastupdate"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "leastupdate"}}checked{{end}} value="leastupdate"> {{ctx.Locale.Tr "repo.issues.filter_sort.leastupdate"}}</label>
+			</div>
+		</div>
+	</form>
+</div>
+

--- a/models/db/search.go
+++ b/models/db/search.go
@@ -12,10 +12,10 @@ func (s SearchOrderBy) String() string {
 
 // Strings for sorting result
 const (
-	SearchOrderBySubjectAlphabetically SearchOrderBy = "CASE WHEN subject != '' THEN subject ELSE name END ASC"
-	SearchOrderBySubjectReverse        SearchOrderBy = "CASE WHEN subject != '' THEN subject ELSE name END DESC"
-	SearchOrderByScore                 SearchOrderBy = "relevance_score ASC, CASE WHEN subject != '' THEN subject ELSE name END ASC"
-	SearchOrderByScoreReverse          SearchOrderBy = "relevance_score DESC, CASE WHEN subject != '' THEN subject ELSE name END ASC"
+	SearchOrderBySubjectAlphabetically SearchOrderBy = "COALESCE(subject.name, repository.name) ASC"
+	SearchOrderBySubjectReverse        SearchOrderBy = "COALESCE(subject.name, repository.name) DESC"
+	SearchOrderByScore                 SearchOrderBy = "relevance_score ASC, COALESCE(subject.name, repository.name) ASC"
+	SearchOrderByScoreReverse          SearchOrderBy = "relevance_score DESC, COALESCE(subject.name, repository.name) ASC"
 	SearchOrderByAlphabetically        SearchOrderBy = "name ASC"
 	SearchOrderByAlphabeticallyReverse SearchOrderBy = "name DESC"
 	SearchOrderByLeastUpdated          SearchOrderBy = "updated_unix ASC"

--- a/models/fixtures/repository.yml
+++ b/models/fixtures/repository.yml
@@ -29,6 +29,7 @@
   size: 0
   is_fsck_enabled: true
   close_issues_via_commit_in_any_branch: false
+  subject_id: 1
 
 -
   id: 2

--- a/models/fixtures/subject.yml
+++ b/models/fixtures/subject.yml
@@ -1,0 +1,12 @@
+-
+  id: 1
+  name: example-subject
+  created_unix: 1588800000
+  updated_unix: 1588800000
+
+-
+  id: 2
+  name: another-subject
+  created_unix: 1588800000
+  updated_unix: 1588800000
+

--- a/models/migrations/custom/v1_25_custom/v324.go
+++ b/models/migrations/custom/v1_25_custom/v324.go
@@ -1,0 +1,48 @@
+// Copyright 2025 okTurtles Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_25_custom
+
+import (
+	"code.gitea.io/gitea/modules/timeutil"
+
+	"xorm.io/xorm"
+)
+
+// CreateSubjectsTable creates the subjects table and populates it with existing subject data
+func CreateSubjectsTable(x *xorm.Engine) error {
+	// Define the new Subject table
+	type Subject struct {
+		ID          int64              `xorm:"pk autoincr"`
+		Name        string             `xorm:"VARCHAR(255) UNIQUE NOT NULL"`
+		CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+		UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+	}
+
+	// Create the subjects table
+	if err := x.Sync(new(Subject)); err != nil {
+		return err
+	}
+
+	// Extract all distinct non-empty subject values from repository.subject
+	type SubjectRow struct {
+		Subject string
+	}
+
+	var subjects []SubjectRow
+	if err := x.SQL("SELECT DISTINCT subject FROM repository WHERE subject != '' AND subject IS NOT NULL ORDER BY subject").Find(&subjects); err != nil {
+		return err
+	}
+
+	// Insert each unique subject value as a new row in the subject table
+	for _, subjectRow := range subjects {
+		subject := Subject{
+			Name: subjectRow.Subject,
+		}
+		if _, err := x.Insert(&subject); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/models/migrations/custom/v1_25_custom/v325.go
+++ b/models/migrations/custom/v1_25_custom/v325.go
@@ -1,0 +1,51 @@
+// Copyright 2025 okTurtles Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_25_custom
+
+import (
+	"xorm.io/xorm"
+)
+
+// AddSubjectForeignKeyToRepository adds the subject_id foreign key column and establishes relationships
+// This is Phase 2 of the subject refactoring (Phase 1 in v324 created the subjects table)
+//
+// NOTE: The legacy `subject` VARCHAR column is kept in this migration for backward compatibility.
+// It can be safely dropped in a future migration (v326 or later) after this release has been
+// deployed and verified in production. The application code no longer uses this column.
+func AddSubjectForeignKeyToRepository(x *xorm.Engine) error {
+	// Temporary repository struct for migration
+	type Repository struct {
+		ID        int64  `xorm:"pk autoincr"`
+		Subject   string `xorm:"VARCHAR(255) NOT NULL DEFAULT ''"` // Legacy field - can be dropped in future migration
+		SubjectID int64  `xorm:"INDEX"`
+	}
+
+	// Step 1: Add SubjectID column to repository table
+	if err := x.Sync(new(Repository)); err != nil {
+		return err
+	}
+
+	// Step 2: Update repositories to reference the subject via foreign key
+	// This is done in a single SQL statement for efficiency
+	_, err := x.Exec(`
+		UPDATE repository 
+		SET subject_id = (
+			SELECT id FROM subject WHERE subject.name = repository.subject
+		)
+		WHERE subject != '' AND subject IS NOT NULL
+	`)
+	if err != nil {
+		return err
+	}
+
+	// Step 3: For repositories with empty subjects, set subject_id to NULL
+	// (they will fall back to using the repository name)
+	_, err = x.Exec("UPDATE repository SET subject_id = NULL WHERE subject = '' OR subject IS NULL")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -398,6 +398,8 @@ func prepareMigrationTasks() []*migration {
 
 		// Forkana migrations 1.25.0:
 		newMigration(323, "Forkana: add subject to repository table", v1_25_custom.AddSubjectToRepository),
+		newMigration(324, "Forkana: create subjects table and populate with existing data", v1_25_custom.CreateSubjectsTable),
+		newMigration(325, "Forkana: add subject_id foreign key to repository table", v1_25_custom.AddSubjectForeignKeyToRepository),
 	}
 	return preparedMigrations
 }

--- a/models/repo/global_uniqueness_test.go
+++ b/models/repo/global_uniqueness_test.go
@@ -49,14 +49,19 @@ func TestIsRepositorySubjectGloballyUnique(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, unique)
 
-	// Create a test repository with a subject to test against
+	// Create a test subject to test against
+	subject, err := repo_model.GetOrCreateSubject(ctx, "Test Subject for Global Uniqueness")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Create a test repository with the subject
 	user := unittest.AssertExistsAndLoadBean(t, &user_model.User{ID: 1})
 	repo := &repo_model.Repository{
 		OwnerID:     user.ID,
 		Owner:       user,
 		LowerName:   "test-subject-repo",
 		Name:        "test-subject-repo",
-		Subject:     "Test Subject for Global Uniqueness",
+		SubjectID:   subject.ID,
 		Description: "Test repository for global uniqueness validation",
 		IsPrivate:   false,
 	}
@@ -98,13 +103,16 @@ func TestCheckCreateRepositoryGlobalUnique(t *testing.T) {
 	err = repo_model.CheckCreateRepositoryGlobalUnique(ctx, user, user, "repo1", "Some Subject", false)
 	assert.True(t, repo_model.IsErrRepoNameGloballyTaken(err))
 
-	// Create a test repository to test subject uniqueness
+	// Create a test subject and repository to test subject uniqueness
+	globalSubject, err := repo_model.GetOrCreateSubject(ctx, "Global Test Subject")
+	assert.NoError(t, err)
+
 	testRepo := &repo_model.Repository{
 		OwnerID:     user.ID,
 		Owner:       user,
 		LowerName:   "test-global-subject",
 		Name:        "test-global-subject",
-		Subject:     "Global Test Subject",
+		SubjectID:   globalSubject.ID,
 		Description: "Test repository for global subject validation",
 		IsPrivate:   false,
 	}

--- a/models/repo/relevance_sorting_test.go
+++ b/models/repo/relevance_sorting_test.go
@@ -152,10 +152,10 @@ func TestCaseInsensitiveMatching(t *testing.T) {
 		keyword  string
 		expected int
 	}{
-		{"MOON", "MOON PROJECT", "moon", 1},        // Exact match, different case
+		{"MOON", "MOON PROJECT", "moon", 2},        // Prefix match (subject "moon project" starts with "moon"), different case
 		{"moon", "Moon Project", "MOON", 2},        // Prefix match, different case
 		{"project", "The MOON Project", "moon", 3}, // Substring match, different case
-		{"test", "Test Repository", "TEST", 1},     // Exact match, different case
+		{"test", "Test Repository", "TEST", 2},     // Prefix match (subject "test repository" starts with "test"), different case
 	}
 
 	for _, tc := range testCases {

--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -359,14 +359,24 @@ func (repo *Repository) LoadSubject(ctx context.Context) error {
 }
 
 // GetSubject returns the subject for the repository.
-// Priority: SubjectRelation > Name (fallback)
+// If a subject is assigned (SubjectID > 0), callers should call LoadSubject(ctx) first.
+// Priority: SubjectRelation.Name > Name (fallback when SubjectID == 0)
 func (repo *Repository) GetSubject() string {
-	// First priority: loaded subject relation
+	// If subject relation is loaded, return its name
 	if repo.SubjectRelation != nil {
 		return repo.SubjectRelation.Name
 	}
 
-	// Fallback: repository name
+	// If no subject is assigned (SubjectID == 0), fallback to repository name
+	if repo.SubjectID == 0 {
+		return repo.Name
+	}
+
+	// SubjectID > 0 but SubjectRelation is nil - this is a programming error
+	// The caller should have called LoadSubject(ctx) before calling GetSubject()
+	log.Error("Repository %d (%s) has SubjectID %d but SubjectRelation is not loaded. Call LoadSubject(ctx) before GetSubject().",
+		repo.ID, repo.FullName(), repo.SubjectID)
+
 	return repo.Name
 }
 

--- a/models/repo/repo_subject_test.go
+++ b/models/repo/repo_subject_test.go
@@ -1,0 +1,170 @@
+// Copyright 2025 okTurtles Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo_test
+
+import (
+	"testing"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unittest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPublicRepositoryBySubject(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Create a test subject
+	subject, err := repo_model.GetOrCreateSubject(ctx, "Test Subject")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Get a repository and assign it the subject
+	repo, err := repo_model.GetRepositoryByID(ctx, 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	repo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsNoAutoTime(ctx, repo, "subject_id")
+	assert.NoError(t, err)
+
+	// Test GetPublicRepositoryBySubject
+	foundRepo, err := repo_model.GetPublicRepositoryBySubject(ctx, "Test Subject")
+	assert.NoError(t, err)
+	assert.NotNil(t, foundRepo)
+	assert.Equal(t, repo.ID, foundRepo.ID)
+	assert.NotNil(t, foundRepo.SubjectRelation)
+	assert.Equal(t, subject.ID, foundRepo.SubjectRelation.ID)
+	assert.Equal(t, "Test Subject", foundRepo.SubjectRelation.Name)
+}
+
+func TestGetPublicRepositoryBySubject_NotFound(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Try to get a repository with a non-existent subject
+	_, err := repo_model.GetPublicRepositoryBySubject(ctx, "Non-Existent Subject")
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectNotExist(err))
+}
+
+func TestGetPublicRepositoryBySubject_PrefersRootRepo(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Create a test subject
+	subject, err := repo_model.GetOrCreateSubject(ctx, "Shared Subject")
+	assert.NoError(t, err)
+
+	// Get two repositories - one root and one fork
+	rootRepo, err := repo_model.GetRepositoryByID(ctx, 1)
+	assert.NoError(t, err)
+	rootRepo.IsFork = false
+	rootRepo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsNoAutoTime(ctx, rootRepo, "subject_id", "is_fork")
+	assert.NoError(t, err)
+
+	forkRepo, err := repo_model.GetRepositoryByID(ctx, 2)
+	assert.NoError(t, err)
+	forkRepo.IsFork = true
+	forkRepo.ForkID = rootRepo.ID
+	forkRepo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsNoAutoTime(ctx, forkRepo, "subject_id", "is_fork", "fork_id")
+	assert.NoError(t, err)
+
+	// GetPublicRepositoryBySubject should return the root repo, not the fork
+	foundRepo, err := repo_model.GetPublicRepositoryBySubject(ctx, "Shared Subject")
+	assert.NoError(t, err)
+	assert.NotNil(t, foundRepo)
+	assert.Equal(t, rootRepo.ID, foundRepo.ID)
+	assert.False(t, foundRepo.IsFork)
+}
+
+func TestGetRepositoryByOwnerAndSubject(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Create a test subject
+	subject, err := repo_model.GetOrCreateSubject(ctx, "Owner Subject Test")
+	assert.NoError(t, err)
+
+	// Get a repository and assign it the subject
+	repo, err := repo_model.GetRepositoryByID(ctx, 1)
+	assert.NoError(t, err)
+	err = repo.LoadOwner(ctx)
+	assert.NoError(t, err)
+
+	repo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsNoAutoTime(ctx, repo, "subject_id")
+	assert.NoError(t, err)
+
+	// Test GetRepositoryByOwnerAndSubject
+	foundRepo, err := repo_model.GetRepositoryByOwnerAndSubject(ctx, repo.Owner.Name, "Owner Subject Test")
+	assert.NoError(t, err)
+	assert.NotNil(t, foundRepo)
+	assert.Equal(t, repo.ID, foundRepo.ID)
+	assert.NotNil(t, foundRepo.SubjectRelation)
+	assert.Equal(t, subject.ID, foundRepo.SubjectRelation.ID)
+}
+
+func TestGetRepositoryByOwnerAndSubject_NotFound(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Try to get a repository with a non-existent subject
+	_, err := repo_model.GetRepositoryByOwnerAndSubject(ctx, "user1", "Non-Existent Subject")
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectNotExist(err))
+}
+
+func TestGetRepositoryByOwnerAndSubject_WrongOwner(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Create a test subject
+	subject, err := repo_model.GetOrCreateSubject(ctx, "Wrong Owner Test")
+	assert.NoError(t, err)
+
+	// Get a repository and assign it the subject
+	repo, err := repo_model.GetRepositoryByID(ctx, 1)
+	assert.NoError(t, err)
+	err = repo.LoadOwner(ctx)
+	assert.NoError(t, err)
+
+	repo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsNoAutoTime(ctx, repo, "subject_id")
+	assert.NoError(t, err)
+
+	// Try to get the repository with a different owner
+	_, err = repo_model.GetRepositoryByOwnerAndSubject(ctx, "different-user", "Wrong Owner Test")
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrRepoNotExist(err))
+}
+
+func TestGetRepositoryByOwnerAndSubject_ReturnsCorrectRepo(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Create a test subject
+	subject, err := repo_model.GetOrCreateSubject(ctx, "Multi Owner Test")
+	assert.NoError(t, err)
+
+	// Get a repository and assign it the subject
+	repo1, err := repo_model.GetRepositoryByID(ctx, 1)
+	assert.NoError(t, err)
+	err = repo1.LoadOwner(ctx)
+	assert.NoError(t, err)
+	repo1.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsNoAutoTime(ctx, repo1, "subject_id")
+	assert.NoError(t, err)
+
+	// GetRepositoryByOwnerAndSubject should return the correct repository for the owner
+	foundRepo, err := repo_model.GetRepositoryByOwnerAndSubject(ctx, repo1.Owner.Name, "Multi Owner Test")
+	assert.NoError(t, err)
+	assert.NotNil(t, foundRepo)
+	assert.Equal(t, repo1.ID, foundRepo.ID)
+	assert.Equal(t, repo1.Owner.Name, foundRepo.OwnerName)
+}
+

--- a/models/repo/repo_test.go
+++ b/models/repo/repo_test.go
@@ -235,3 +235,53 @@ func TestIsValidSSHAccessRepoName(t *testing.T) {
 	assert.False(t, IsValidSSHAccessRepoName("foo.git"))
 	assert.False(t, IsValidSSHAccessRepoName("foo.RSS"))
 }
+
+func TestGetPublicRepositoryByName(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Test getting a repository by name
+	// Repository ID 1 is "repo1" owned by user2, and it's public
+	repo, err := GetPublicRepositoryByName(ctx, "repo1")
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+	assert.Equal(t, "repo1", repo.Name)
+	assert.Equal(t, int64(1), repo.ID)
+	assert.False(t, repo.IsPrivate)
+
+	// Test getting a non-existent repository
+	_, err = GetPublicRepositoryByName(ctx, "non-existent-repo-xyz")
+	assert.Error(t, err)
+	assert.True(t, IsErrRepoNotExist(err))
+
+	// Test that private repositories are not returned
+	// Repository ID 2 is "repo2" owned by user2, and it's private
+	_, err = GetPublicRepositoryByName(ctx, "repo2")
+	assert.Error(t, err)
+	assert.True(t, IsErrRepoNotExist(err))
+}
+
+func TestGetPublicRepositoryByName_PrefersRootOverFork(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Note: The test fixtures don't have repositories with the same name where one is a fork
+	// This test verifies the ordering logic by checking that is_fork is considered in the ORDER BY clause
+
+	// Test with repo1 which is not a fork
+	repo, err := GetPublicRepositoryByName(ctx, "repo1")
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+	assert.Equal(t, "repo1", repo.Name)
+	assert.False(t, repo.IsFork, "repo1 should not be a fork")
+
+	// The key improvement is in the SQL query:
+	// Old: ORDER BY `updated_unix` DESC
+	// New: ORDER BY `is_fork` ASC, `updated_unix` DESC
+	// This ensures that when multiple repos have the same name:
+	// 1. Non-forks (is_fork=false=0) come before forks (is_fork=true=1)
+	// 2. Within each group, most recently updated comes first
+	//
+	// This fix ensures that /explore/articles/history/{reponame} displays the root repository
+	// and the API fork graph endpoint builds the hierarchy from the correct root.
+}

--- a/models/repo/search_score_test.go
+++ b/models/repo/search_score_test.go
@@ -119,9 +119,9 @@ func TestMultipleKeywordScoring(t *testing.T) {
 		keywords           string
 		expectedTotalScore int
 	}{
-		{"moon-landing", "Moon Landing", "moon,landing", 4},           // 2 + 2 (both prefix matches)
+		{"moon-landing", "Moon Landing", "moon,landing", 5},           // 2 + 3 (prefix + substring)
 		{"apollo-moon", "Apollo Moon Program", "moon,landing", 7},     // 3 + 4 (substring + no match)
-		{"space-landing", "Space Landing Mission", "moon,landing", 6}, // 4 + 2 (no match + prefix)
+		{"space-landing", "Space Landing Mission", "moon,landing", 7}, // 4 + 3 (no match + substring)
 		{"mars-rover", "Mars Rover Project", "moon,landing", 8},       // 4 + 4 (no match + no match)
 	}
 
@@ -170,17 +170,16 @@ func calculateMockRelevanceScore(name, subject, keyword string) int {
 	keyword = strings.ToLower(strings.TrimSpace(keyword))
 
 	// Determine the display field (subject if available, otherwise name)
+	// This matches the COALESCE(subject.name, repository.name) logic
 	displayField := strings.ToLower(name)
 	if subject != "" {
 		displayField = strings.ToLower(subject)
 	}
 
-	repoName := strings.ToLower(name)
-
 	// Calculate score based on priority:
 	// 1 = exact match, 2 = prefix match, 3 = substring match, 4 = no match
+	// Only check the display field (subject takes priority over name)
 
-	// Check display field first
 	if displayField == keyword {
 		return 1 // Exact match
 	}
@@ -188,17 +187,6 @@ func calculateMockRelevanceScore(name, subject, keyword string) int {
 		return 2 // Prefix match
 	}
 	if strings.Contains(displayField, keyword) {
-		return 3 // Substring match
-	}
-
-	// Check name field as fallback
-	if repoName == keyword {
-		return 1 // Exact match
-	}
-	if strings.HasPrefix(repoName, keyword) {
-		return 2 // Prefix match
-	}
-	if strings.Contains(repoName, keyword) {
 		return 3 // Substring match
 	}
 

--- a/models/repo/subject.go
+++ b/models/repo/subject.go
@@ -1,0 +1,174 @@
+// Copyright 2025 okTurtles Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo
+
+import (
+	"context"
+	"fmt"
+
+	"code.gitea.io/gitea/models/db"
+	"code.gitea.io/gitea/modules/timeutil"
+
+	"xorm.io/builder"
+)
+
+// Subject represents a repository subject that can be shared across repositories
+type Subject struct {
+	ID          int64              `xorm:"pk autoincr"`
+	Name        string             `xorm:"VARCHAR(255) UNIQUE NOT NULL"`
+	CreatedUnix timeutil.TimeStamp `xorm:"INDEX created"`
+	UpdatedUnix timeutil.TimeStamp `xorm:"INDEX updated"`
+}
+
+func init() {
+	db.RegisterModel(new(Subject))
+}
+
+// TableName returns the table name for Subject
+func (s *Subject) TableName() string {
+	return "subject"
+}
+
+// GetOrCreateSubject gets an existing subject by name or creates a new one if it doesn't exist
+func GetOrCreateSubject(ctx context.Context, name string) (*Subject, error) {
+	if name == "" {
+		return nil, nil
+	}
+
+	// Try to get existing subject
+	subject := &Subject{Name: name}
+	has, err := db.GetEngine(ctx).Get(subject)
+	if err != nil {
+		return nil, err
+	}
+	if has {
+		return subject, nil
+	}
+
+	// Create new subject
+	if err := db.Insert(ctx, subject); err != nil {
+		// Handle race condition: another process might have created it
+		has, err := db.GetEngine(ctx).Get(subject)
+		if err != nil {
+			return nil, err
+		}
+		if has {
+			return subject, nil
+		}
+		return nil, fmt.Errorf("failed to create subject: %w", err)
+	}
+
+	return subject, nil
+}
+
+// GetSubjectByID gets a subject by its ID
+func GetSubjectByID(ctx context.Context, id int64) (*Subject, error) {
+	subject := &Subject{ID: id}
+	has, err := db.GetEngine(ctx).Get(subject)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, ErrSubjectNotExist{ID: id}
+	}
+	return subject, nil
+}
+
+// GetSubjectByName gets a subject by its name
+func GetSubjectByName(ctx context.Context, name string) (*Subject, error) {
+	subject := &Subject{Name: name}
+	has, err := db.GetEngine(ctx).Get(subject)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return nil, ErrSubjectNotExist{Name: name}
+	}
+	return subject, nil
+}
+
+// UpdateSubject updates a subject's properties
+func UpdateSubject(ctx context.Context, subject *Subject) error {
+	_, err := db.GetEngine(ctx).ID(subject.ID).AllCols().Update(subject)
+	return err
+}
+
+// DeleteSubject deletes a subject (only if no repositories reference it)
+func DeleteSubject(ctx context.Context, id int64) error {
+	// Check if any repositories reference this subject
+	count, err := db.GetEngine(ctx).Where("subject_id = ?", id).Count(new(Repository))
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return ErrSubjectInUse{ID: id, RepoCount: count}
+	}
+
+	_, err = db.GetEngine(ctx).ID(id).Delete(new(Subject))
+	return err
+}
+
+// FindSubjects finds subjects based on options
+func FindSubjects(ctx context.Context, opts FindSubjectsOptions) ([]*Subject, int64, error) {
+	sess := db.GetEngine(ctx).Where(opts.ToConds())
+	
+	if opts.PageSize > 0 {
+		sess = db.SetSessionPagination(sess, &opts.ListOptions)
+	}
+
+	subjects := make([]*Subject, 0, opts.PageSize)
+	count, err := sess.FindAndCount(&subjects)
+	return subjects, count, err
+}
+
+// FindSubjectsOptions represents options for finding subjects
+type FindSubjectsOptions struct {
+	db.ListOptions
+	Keyword string
+}
+
+// ToConds converts options to database conditions
+func (opts FindSubjectsOptions) ToConds() builder.Cond {
+	cond := builder.NewCond()
+	if opts.Keyword != "" {
+		cond = cond.And(builder.Like{"LOWER(name)", opts.Keyword})
+	}
+	return cond
+}
+
+// ErrSubjectNotExist represents a "SubjectNotExist" error
+type ErrSubjectNotExist struct {
+	ID   int64
+	Name string
+}
+
+// IsErrSubjectNotExist checks if an error is ErrSubjectNotExist
+func IsErrSubjectNotExist(err error) bool {
+	_, ok := err.(ErrSubjectNotExist)
+	return ok
+}
+
+func (err ErrSubjectNotExist) Error() string {
+	if err.Name != "" {
+		return fmt.Sprintf("subject does not exist [name: %s]", err.Name)
+	}
+	return fmt.Sprintf("subject does not exist [id: %d]", err.ID)
+}
+
+// ErrSubjectInUse represents a "SubjectInUse" error
+type ErrSubjectInUse struct {
+	ID        int64
+	RepoCount int64
+}
+
+// IsErrSubjectInUse checks if an error is ErrSubjectInUse
+func IsErrSubjectInUse(err error) bool {
+	_, ok := err.(ErrSubjectInUse)
+	return ok
+}
+
+func (err ErrSubjectInUse) Error() string {
+	return fmt.Sprintf("subject is in use by %d repositories [id: %d]", err.RepoCount, err.ID)
+}
+

--- a/models/repo/subject_test.go
+++ b/models/repo/subject_test.go
@@ -1,0 +1,165 @@
+// Copyright 2025 okTurtles Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package repo_test
+
+import (
+	"testing"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unittest"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOrCreateSubject(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Test creating a new subject
+	subject1, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject 1")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject1)
+	assert.Equal(t, "Test Subject 1", subject1.Name)
+	assert.NotZero(t, subject1.ID)
+
+	// Test getting existing subject
+	subject2, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject 1")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject2)
+	assert.Equal(t, subject1.ID, subject2.ID)
+	assert.Equal(t, subject1.Name, subject2.Name)
+
+	// Test with empty name
+	subject3, err := repo_model.GetOrCreateSubject(t.Context(), "")
+	assert.NoError(t, err)
+	assert.Nil(t, subject3)
+}
+
+func TestGetSubjectByID(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create a subject first
+	subject1, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject 2")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject1)
+
+	// Get by ID
+	subject2, err := repo_model.GetSubjectByID(t.Context(), subject1.ID)
+	assert.NoError(t, err)
+	assert.NotNil(t, subject2)
+	assert.Equal(t, subject1.ID, subject2.ID)
+	assert.Equal(t, subject1.Name, subject2.Name)
+
+	// Test with non-existent ID
+	_, err = repo_model.GetSubjectByID(t.Context(), 999999)
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectNotExist(err))
+}
+
+func TestGetSubjectByName(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create a subject first
+	subject1, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject 3")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject1)
+
+	// Get by name
+	subject2, err := repo_model.GetSubjectByName(t.Context(), "Test Subject 3")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject2)
+	assert.Equal(t, subject1.ID, subject2.ID)
+	assert.Equal(t, subject1.Name, subject2.Name)
+
+	// Test with non-existent name
+	_, err = repo_model.GetSubjectByName(t.Context(), "Non-existent Subject")
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectNotExist(err))
+}
+
+func TestRepositoryLoadSubject(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create a subject
+	subject, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject 4")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Get a repository (assuming repo with ID 1 exists in test data)
+	repo, err := repo_model.GetRepositoryByID(t.Context(), 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	// Set the subject ID
+	repo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsWithAutoTime(t.Context(), repo, "subject_id")
+	assert.NoError(t, err)
+
+	// Load the subject
+	err = repo.LoadSubject(t.Context())
+	assert.NoError(t, err)
+	assert.NotNil(t, repo.SubjectRelation)
+	assert.Equal(t, subject.ID, repo.SubjectRelation.ID)
+	assert.Equal(t, subject.Name, repo.SubjectRelation.Name)
+
+	// Test GetSubject method
+	assert.Equal(t, subject.Name, repo.GetSubject())
+}
+
+func TestRepositoryGetSubjectFallback(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Get a repository
+	repo, err := repo_model.GetRepositoryByID(t.Context(), 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	// Clear subject fields
+	repo.SubjectID = 0
+	repo.SubjectRelation = nil
+
+	// Should fall back to repository name
+	assert.Equal(t, repo.Name, repo.GetSubject())
+}
+
+func TestDeleteSubject(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create a subject
+	subject, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject to Delete")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Should be able to delete when no repos reference it
+	err = repo_model.DeleteSubject(t.Context(), subject.ID)
+	assert.NoError(t, err)
+
+	// Verify it's deleted
+	_, err = repo_model.GetSubjectByID(t.Context(), subject.ID)
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectNotExist(err))
+}
+
+func TestDeleteSubjectInUse(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create a subject
+	subject, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject In Use")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Get a repository and assign the subject
+	repo, err := repo_model.GetRepositoryByID(t.Context(), 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	repo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsWithAutoTime(t.Context(), repo, "subject_id")
+	assert.NoError(t, err)
+
+	// Should not be able to delete when repos reference it
+	err = repo_model.DeleteSubject(t.Context(), subject.ID)
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectInUse(err))
+}
+

--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -164,7 +164,7 @@ type EditRepoOption struct {
 	// name of the repository
 	// unique: true
 	Name *string `json:"name,omitempty" binding:"OmitEmpty;AlphaDashDot;MaxSize(100);"`
-	// subject of the repository
+	// subject of the repository (read-only, cannot be modified after creation)
 	Subject *string `json:"subject,omitempty" binding:"MaxSize(255)"`
 	// a short description of the repository.
 	Description *string `json:"description,omitempty" binding:"MaxSize(2048)"`

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -710,8 +710,11 @@ func updateBasicProperties(ctx *context.APIContext, opts api.EditRepoOption) err
 	repo.Name = newRepoName
 	repo.LowerName = strings.ToLower(newRepoName)
 
-	if opts.Subject != nil {
-		repo.Subject = *opts.Subject
+	// Subject cannot be edited after repository creation
+	if opts.Subject != nil && *opts.Subject != repo.GetSubject() {
+		err := fmt.Errorf("subject cannot be modified after repository creation")
+		ctx.APIError(http.StatusUnprocessableEntity, err)
+		return err
 	}
 
 	if opts.Description != nil {

--- a/routers/web/repo/setting/setting.go
+++ b/routers/web/repo/setting/setting.go
@@ -204,7 +204,14 @@ func handleSettingsPostUpdate(ctx *context.Context) {
 	// In case it's just a case change.
 	repo.Name = newRepoName
 	repo.LowerName = strings.ToLower(newRepoName)
-	repo.Subject = form.Subject
+
+	// Subject cannot be edited after repository creation
+	if form.Subject != repo.GetSubject() {
+		ctx.Data["Err_Subject"] = true
+		ctx.RenderWithErr(ctx.Tr("repo.subject_cannot_be_modified"), tplSettingsOptions, &form)
+		return
+	}
+
 	repo.Description = form.Description
 	repo.Website = form.Website
 	repo.IsTemplate = form.Template

--- a/routers/web/repo/setting/settings_test.go
+++ b/routers/web/repo/setting/settings_test.go
@@ -418,3 +418,38 @@ func TestRepositorySubjectLoaded(t *testing.T) {
 	assert.Equal(t, subject.ID, repo.SubjectRelation.ID)
 	assert.Equal(t, "Test Subject for Settings", repo.SubjectRelation.Name)
 }
+
+func TestRepositorySubjectLoadedByName(t *testing.T) {
+	unittest.PrepareTestEnv(t)
+
+	// Create a repository with a subject
+	subject, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject for History View")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Get repository with ID 1 from fixtures
+	repo, err := repo_model.GetRepositoryByID(t.Context(), 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo)
+
+	// Set the subject ID
+	repo.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsWithAutoTime(t.Context(), repo, "subject_id")
+	assert.NoError(t, err)
+
+	// Load owner and subject (simulating what RepoAssignmentByName does)
+	err = repo.LoadOwner(t.Context())
+	assert.NoError(t, err)
+
+	err = repo.LoadSubject(t.Context())
+	assert.NoError(t, err)
+
+	// Verify that GetSubject() returns the subject name, not the repo name
+	assert.Equal(t, "Test Subject for History View", repo.GetSubject())
+	assert.NotEqual(t, repo.Name, repo.GetSubject())
+
+	// Verify that SubjectRelation is properly loaded
+	assert.NotNil(t, repo.SubjectRelation)
+	assert.Equal(t, subject.ID, repo.SubjectRelation.ID)
+	assert.Equal(t, "Test Subject for History View", repo.SubjectRelation.Name)
+}

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -493,6 +493,8 @@ func registerWebRoutes(m *web.Router) {
 
 	m.Post("/-/markup", reqSignIn, web.Bind(structs.MarkupOption{}), misc.Markup)
 
+	m.Get("/subject/{subjectname}", optSignIn, context.RepoAssignmentBySubject, context.RepoRefByDefaultBranch(), repo.SetEditorconfigIfExists, explore.RepoHistory)
+
 	m.Group("/explore", func() {
 		m.Get("", func(ctx *context.Context) {
 			ctx.Redirect(setting.AppSubURL + "/explore/articles")
@@ -1172,6 +1174,8 @@ func registerWebRoutes(m *web.Router) {
 		ctxDataSet("PageIsRepoSettings", true, "LFSStartServer", setting.LFS.StartServer),
 	)
 	// end "/{username}/{reponame}/settings"
+
+	m.Get("/article/{username}/{subjectname}", optSignIn, context.RepoAssignmentByOwnerAndSubject, context.RepoRefByType(git.RefTypeBranch), repo.SetEditorconfigIfExists, repo.Home)
 
 	// user/org home, including rss feeds like "/{username}/{reponame}.rss"
 	m.Get("/{username}/{reponame}", optSignIn, context.RepoAssignment, context.RepoRefByType(git.RefTypeBranch), repo.SetEditorconfigIfExists, repo.Home)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -497,11 +497,13 @@ func registerWebRoutes(m *web.Router) {
 
 	m.Group("/explore", func() {
 		m.Get("", func(ctx *context.Context) {
-			ctx.Redirect(setting.AppSubURL + "/explore/articles")
+			ctx.Redirect(setting.AppSubURL + "/explore/subjects")
 		})
 		m.Get("/articles", explore.Repos)
+		m.Get("/subjects", explore.Subjects)
 		m.Get("/articles/history/{reponame}", optSignIn, context.RepoAssignmentByName, context.RepoRefByDefaultBranch(), repo.SetEditorconfigIfExists, explore.RepoHistory)
 		m.Get("/articles/sitemap-{idx}.xml", sitemapEnabled, explore.Repos)
+		m.Get("/subjects/sitemap-{idx}.xml", sitemapEnabled, explore.Subjects)
 		m.Get("/users", explore.Users)
 		m.Get("/users/sitemap-{idx}.xml", sitemapEnabled, explore.Users)
 		m.Get("/organizations", explore.Organizations)

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -1447,3 +1447,297 @@ func RepoAssignmentByName(ctx *Context) {
 	ctx.Data["CanCompareOrPull"] = canCompare
 	ctx.Data["PullRequestCtx"] = ctx.Repo.PullRequest
 }
+
+// RepoAssignmentBySubject assigns repository context by subject name only
+// This is used for routes like /subject/{subjectname} that display the root repository for a subject
+func RepoAssignmentBySubject(ctx *Context) {
+	subjectName := ctx.PathParam("subjectname")
+	if subjectName == "" {
+		ctx.NotFound(errors.New("subject name is required"))
+		return
+	}
+
+	// Find repository by subject name (prioritizes root repositories)
+	repo, err := repo_model.GetPublicRepositoryBySubject(ctx, subjectName)
+	if err != nil {
+		if repo_model.IsErrRepoNotExist(err) || repo_model.IsErrSubjectNotExist(err) {
+			ctx.NotFound(err)
+		} else {
+			ctx.ServerError("GetPublicRepositoryBySubject", err)
+		}
+		return
+	}
+
+	// Load repository owner
+	if err = repo.LoadOwner(ctx); err != nil {
+		ctx.ServerError("LoadOwner", err)
+		return
+	}
+
+	// Subject is already loaded by GetPublicRepositoryBySubject
+	// Set up repository context similar to standard RepoAssignment
+	ctx.Repo = &Repository{
+		Repository: repo,
+	}
+
+	// Initialize Git repository
+	ctx.Repo.GitRepo, err = gitrepo.RepositoryFromRequestContextOrOpen(ctx, repo)
+	if err != nil {
+		if strings.Contains(err.Error(), "repository does not exist") || strings.Contains(err.Error(), "no such file or directory") {
+			log.Error("Repository %-v has a broken repository on the file system: %s Error: %v", ctx.Repo.Repository, ctx.Repo.Repository.RepoPath(), err)
+			ctx.Repo.Repository.MarkAsBrokenEmpty()
+			ctx.NotFound(errors.New("repository not found or corrupted"))
+		} else {
+			ctx.ServerError("gitrepo.RepositoryFromRequestContextOrOpen", err)
+		}
+		return
+	}
+
+	// Verify repository has a valid default branch
+	if repo.DefaultBranch == "" {
+		log.Warn("Repository %-v has no default branch set", repo)
+		ctx.NotFound(errors.New("repository has no default branch"))
+		return
+	}
+
+	// Check repository access permissions
+	perm, err := access_model.GetUserRepoPermission(ctx, repo, ctx.Doer)
+	if err != nil {
+		ctx.ServerError("GetUserRepoPermission", err)
+		return
+	}
+
+	if !perm.HasAnyUnitAccessOrPublicAccess() && !canWriteAsMaintainer(ctx) {
+		if ctx.FormString("go-get") == "1" {
+			EarlyResponseForGoGetMeta(ctx)
+			return
+		}
+		ctx.NotFound(nil)
+		return
+	}
+
+	ctx.Repo.Permission = perm
+	ctx.Data["Permission"] = &ctx.Repo.Permission
+
+	// Set up basic repository data for templates
+	ctx.Data["Title"] = repo.Owner.Name + "/" + repo.Name
+	ctx.Data["Repository"] = repo
+	ctx.Data["Owner"] = ctx.Repo.Repository.Owner
+	ctx.Data["RepoName"] = ctx.Repo.Repository.Name
+	ctx.Data["IsEmptyRepo"] = ctx.Repo.Repository.IsEmpty
+	ctx.Data["CanWriteCode"] = ctx.Repo.CanWrite(unit_model.TypeCode)
+	ctx.Data["CanWriteIssues"] = ctx.Repo.CanWrite(unit_model.TypeIssues)
+	ctx.Data["CanWritePulls"] = ctx.Repo.CanWrite(unit_model.TypePullRequests)
+	ctx.Data["CanWriteActions"] = ctx.Repo.CanWrite(unit_model.TypeActions)
+
+	// Set up repository link data
+	ctx.Repo.RepoLink = repo.Link()
+	ctx.Data["RepoLink"] = ctx.Repo.RepoLink
+	ctx.Data["FeedURL"] = ctx.Repo.RepoLink
+
+	// Set up release count data
+	ctx.Data["NumTags"], err = db.Count[repo_model.Release](ctx, repo_model.FindReleasesOptions{
+		IncludeTags: true,
+		HasSha1:     optional.Some(true),
+		RepoID:      ctx.Repo.Repository.ID,
+	})
+	if err != nil {
+		ctx.ServerError("GetReleaseCountByRepoID", err)
+		return
+	}
+	ctx.Data["NumReleases"], err = db.Count[repo_model.Release](ctx, repo_model.FindReleasesOptions{
+		IncludeDrafts: ctx.Repo.CanWrite(unit_model.TypeReleases),
+		RepoID:        ctx.Repo.Repository.ID,
+	})
+	if err != nil {
+		ctx.ServerError("GetReleaseCountByRepoID", err)
+		return
+	}
+
+	// Set up contributor count data
+	ctx.Data["ContributorCount"] = int64(0)
+	if !repo.IsEmpty && ctx.Repo.GitRepo != nil {
+		contributorCount, err := ctx.Repo.GitRepo.GetContributorCount(repo.DefaultBranch)
+		if err != nil {
+			log.Warn("Failed to get contributor count for repository %s: %v", repo.FullName(), err)
+		} else {
+			ctx.Data["ContributorCount"] = contributorCount
+		}
+	}
+}
+
+// RepoAssignmentByOwnerAndSubject assigns repository context by owner name and subject name
+// This is used for routes like /article/{username}/{subjectname} that display a specific user's repository
+func RepoAssignmentByOwnerAndSubject(ctx *Context) {
+	userName := ctx.PathParam("username")
+	subjectName := ctx.PathParam("subjectname")
+
+	if userName == "" || subjectName == "" {
+		ctx.NotFound(errors.New("username and subject name are required"))
+		return
+	}
+
+	// Find repository by owner and subject name
+	repo, err := repo_model.GetRepositoryByOwnerAndSubject(ctx, userName, subjectName)
+	if err != nil {
+		if repo_model.IsErrRepoNotExist(err) || repo_model.IsErrSubjectNotExist(err) {
+			ctx.NotFound(err)
+		} else {
+			ctx.ServerError("GetRepositoryByOwnerAndSubject", err)
+		}
+		return
+	}
+
+	// Load repository owner
+	if err = repo.LoadOwner(ctx); err != nil {
+		ctx.ServerError("LoadOwner", err)
+		return
+	}
+
+	// Set up repository owner context
+	ctx.Repo.Owner = repo.Owner
+	ctx.ContextUser = ctx.Repo.Owner
+	ctx.Data["ContextUser"] = ctx.ContextUser
+
+	// Subject is already loaded by GetRepositoryByOwnerAndSubject
+	// Use the standard repoAssignment helper to set up the repository context
+	repoAssignment(ctx, repo)
+	if ctx.Written() {
+		return
+	}
+
+	// Set up repository link data
+	ctx.Repo.RepoLink = repo.Link()
+	ctx.Data["RepoLink"] = ctx.Repo.RepoLink
+	ctx.Data["FeedURL"] = ctx.Repo.RepoLink
+
+	// Initialize Git repository (required for RepoRefByType middleware)
+	if ctx.Repo.GitRepo != nil {
+		setting.PanicInDevOrTesting("RepoAssignmentByOwnerAndSubject: GitRepo should be nil")
+		_ = ctx.Repo.GitRepo.Close()
+		ctx.Repo.GitRepo = nil
+	}
+
+	ctx.Repo.GitRepo, err = gitrepo.RepositoryFromRequestContextOrOpen(ctx, repo)
+	if err != nil {
+		if strings.Contains(err.Error(), "repository does not exist") || strings.Contains(err.Error(), "no such file or directory") {
+			log.Error("Repository %-v has a broken repository on the file system: %s Error: %v", ctx.Repo.Repository, ctx.Repo.Repository.RepoPath(), err)
+			ctx.Repo.Repository.MarkAsBrokenEmpty()
+			ctx.NotFound(errors.New("repository not found or corrupted"))
+		} else {
+			ctx.ServerError("gitrepo.RepositoryFromRequestContextOrOpen", err)
+		}
+		return
+	}
+
+	// Set up branch count for repository statistics (only for non-empty repos)
+	if !ctx.Repo.Repository.IsEmpty {
+		branchOpts := git_model.FindBranchOptions{
+			RepoID:          ctx.Repo.Repository.ID,
+			IsDeletedBranch: optional.Some(false),
+			ListOptions:     db.ListOptionsAll,
+		}
+		branchesTotal, err := db.Count[git_model.Branch](ctx, branchOpts)
+		if err != nil {
+			ctx.ServerError("CountBranches", err)
+			return
+		}
+
+		// non-empty repo should have at least 1 branch, so this repository's branches haven't been synced yet
+		if branchesTotal == 0 { // fallback to do a sync immediately
+			branchesTotal, err = repo_module.SyncRepoBranches(ctx, ctx.Repo.Repository.ID, 0)
+			if err != nil {
+				ctx.ServerError("SyncRepoBranches", err)
+				return
+			}
+		}
+
+		ctx.Data["BranchesCount"] = branchesTotal
+	}
+
+	// Set up tag and release counts for repository statistics
+	ctx.Data["NumTags"], err = db.Count[repo_model.Release](ctx, repo_model.FindReleasesOptions{
+		IncludeDrafts: true,
+		IncludeTags:   true,
+		HasSha1:       optional.Some(true), // only draft releases which are created with existing tags
+		RepoID:        ctx.Repo.Repository.ID,
+	})
+	if err != nil {
+		ctx.ServerError("GetReleaseCountByRepoID", err)
+		return
+	}
+	ctx.Data["NumReleases"], err = db.Count[repo_model.Release](ctx, repo_model.FindReleasesOptions{
+		// only show draft releases for users who can write, read-only users shouldn't see draft releases.
+		IncludeDrafts: ctx.Repo.CanWrite(unit_model.TypeReleases),
+		RepoID:        ctx.Repo.Repository.ID,
+	})
+	if err != nil {
+		ctx.ServerError("GetReleaseCountByRepoID", err)
+		return
+	}
+
+	// Set up additional repository data for templates (similar to RepoAssignment)
+	ctx.Data["Title"] = repo.Owner.Name + "/" + repo.Name
+	ctx.Data["Repository"] = repo
+	ctx.Data["Owner"] = ctx.Repo.Repository.Owner
+	ctx.Data["CanWriteCode"] = ctx.Repo.CanWrite(unit_model.TypeCode)
+	ctx.Data["CanWriteIssues"] = ctx.Repo.CanWrite(unit_model.TypeIssues)
+	ctx.Data["CanWritePulls"] = ctx.Repo.CanWrite(unit_model.TypePullRequests)
+	ctx.Data["CanWriteActions"] = ctx.Repo.CanWrite(unit_model.TypeActions)
+
+	canSignedUserFork, err := repo_module.CanUserForkRepo(ctx, ctx.Doer, ctx.Repo.Repository)
+	if err != nil {
+		ctx.ServerError("CanUserForkRepo", err)
+		return
+	}
+	ctx.Data["CanSignedUserFork"] = canSignedUserFork
+
+	userAndOrgForks, err := repo_model.GetForksByUserAndOrgs(ctx, ctx.Doer, ctx.Repo.Repository)
+	if err != nil {
+		ctx.ServerError("GetForksByUserAndOrgs", err)
+		return
+	}
+	ctx.Data["UserAndOrgForks"] = userAndOrgForks
+
+	// canSignedUserFork is true if the current user doesn't have a fork of this repo yet or
+	// if he owns an org that doesn't have a fork of this repo yet
+	// If multiple forks are available or if the user can fork to another account, but there is already a fork: open selection dialog
+	ctx.Data["ShowForkModal"] = len(userAndOrgForks) > 1 || (canSignedUserFork && len(userAndOrgForks) > 0)
+
+	ctx.Data["RepoCloneLink"] = repo.CloneLink(ctx, ctx.Doer)
+
+	cloneButtonShowHTTPS := !setting.Repository.DisableHTTPGit
+	cloneButtonShowSSH := !setting.SSH.Disabled && (ctx.IsSigned || setting.SSH.ExposeAnonymous)
+	if !cloneButtonShowHTTPS && !cloneButtonShowSSH {
+		// We have to show at least one link, so we just show the HTTPS
+		cloneButtonShowHTTPS = true
+	}
+	ctx.Data["CloneButtonShowHTTPS"] = cloneButtonShowHTTPS
+	ctx.Data["CloneButtonShowSSH"] = cloneButtonShowSSH
+	ctx.Data["CloneButtonOriginLink"] = ctx.Data["RepoCloneLink"] // it may be rewritten to the WikiCloneLink by the router middleware
+
+	ctx.Data["RepoSearchEnabled"] = setting.Indexer.RepoIndexerEnabled
+	if setting.Indexer.RepoIndexerEnabled {
+		ctx.Data["CodeIndexerUnavailable"] = !code_indexer.IsAvailable(ctx)
+	}
+
+	if ctx.IsSigned {
+		ctx.Data["IsWatchingRepo"] = repo_model.IsWatching(ctx, ctx.Doer.ID, repo.ID)
+		ctx.Data["IsStaringRepo"] = repo_model.IsStaring(ctx, ctx.Doer.ID, repo.ID)
+	}
+
+	// Handle fork base repository
+	if repo.IsFork {
+		RetrieveBaseRepo(ctx, repo)
+		if ctx.Written() {
+			return
+		}
+	}
+
+	if repo.IsGenerated() {
+		RetrieveTemplateRepo(ctx, repo)
+		if ctx.Written() {
+			return
+		}
+	}
+}

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -501,6 +501,12 @@ func repoAssignment(ctx *Context, repo *repo_model.Repository) {
 		return
 	}
 
+	// Load subject relation for display in forms and templates
+	if err = repo.LoadSubject(ctx); err != nil {
+		ctx.ServerError("LoadSubject", err)
+		return
+	}
+
 	if ctx.DoerNeedTwoFactorAuth() {
 		ctx.Repo.Permission = access_model.PermissionNoAccess()
 	} else {

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -1161,6 +1161,12 @@ func RepoAssignmentByName(ctx *Context) {
 		return
 	}
 
+	// Load subject relation for display in forms and templates
+	if err = repo.LoadSubject(ctx); err != nil {
+		ctx.ServerError("LoadSubject", err)
+		return
+	}
+
 	// Set up repository context similar to standard RepoAssignment
 	ctx.Repo = &Repository{
 		Repository: repo,

--- a/services/convert/repository.go
+++ b/services/convert/repository.go
@@ -186,6 +186,9 @@ func innerToRepo(ctx context.Context, repo *repo_model.Repository, permissionInR
 		return nil
 	}
 
+	// Load subject relation if available
+	_ = repo.LoadSubject(ctx) // Ignore error, will fall back to legacy field or name
+
 	repoAPIURL := repo.APIURL()
 
 	return &api.Repository{

--- a/services/repository/create.go
+++ b/services/repository/create.go
@@ -231,12 +231,22 @@ func CreateRepositoryDirectly(ctx context.Context, doer, owner *user_model.User,
 		opts.ObjectFormatName = git.Sha1ObjectFormat.Name()
 	}
 
+	// Get or create subject if provided
+	var subjectID int64
+	if opts.Subject != "" {
+		subject, err := repo_model.GetOrCreateSubject(ctx, opts.Subject)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get or create subject: %w", err)
+		}
+		subjectID = subject.ID
+	}
+
 	repo := &repo_model.Repository{
 		OwnerID:                         owner.ID,
 		Owner:                           owner,
 		OwnerName:                       owner.Name,
 		Name:                            opts.Name,
-		Subject:                         opts.Subject,
+		SubjectID:                       subjectID,
 		LowerName:                       strings.ToLower(opts.Name),
 		Description:                     opts.Description,
 		OriginalURL:                     opts.OriginalURL,

--- a/services/repository/fork.go
+++ b/services/repository/fork.go
@@ -88,6 +88,7 @@ func ForkRepository(ctx context.Context, doer, owner *user_model.User, opts Fork
 	if opts.SingleBranch != "" {
 		defaultBranch = opts.SingleBranch
 	}
+
 	repo := &repo_model.Repository{
 		OwnerID:          owner.ID,
 		Owner:            owner,
@@ -100,6 +101,7 @@ func ForkRepository(ctx context.Context, doer, owner *user_model.User, opts Fork
 		IsEmpty:          opts.BaseRepo.IsEmpty,
 		IsFork:           true,
 		ForkID:           opts.BaseRepo.ID,
+		SubjectID:        opts.BaseRepo.SubjectID,
 		ObjectFormatName: opts.BaseRepo.ObjectFormatName,
 		Status:           repo_model.RepositoryBeingMigrated,
 	}

--- a/services/repository/template.go
+++ b/services/repository/template.go
@@ -73,12 +73,22 @@ func GenerateRepository(ctx context.Context, doer, owner *user_model.User, templ
 		}
 	}
 
+	// Get or create subject if provided
+	var subjectID int64
+	if opts.Subject != "" {
+		subject, err := repo_model.GetOrCreateSubject(ctx, opts.Subject)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get or create subject: %w", err)
+		}
+		subjectID = subject.ID
+	}
+
 	generateRepo := &repo_model.Repository{
 		OwnerID:          owner.ID,
 		Owner:            owner,
 		OwnerName:        owner.Name,
 		Name:             opts.Name,
-		Subject:          opts.Subject,
+		SubjectID:        subjectID,
 		LowerName:        strings.ToLower(opts.Name),
 		Description:      opts.Description,
 		DefaultBranch:    opts.DefaultBranch,

--- a/templates/explore/subjects.tmpl
+++ b/templates/explore/subjects.tmpl
@@ -1,0 +1,11 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content explore subjects">
+	<div class="ui container">
+		{{template "explore/navbar" .}}
+		{{template "shared/subject/search" .}}
+		{{template "shared/subject/list" .}}
+		{{template "base/paginate" .}}
+	</div>
+</div>
+{{template "base/footer" .}}
+

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -14,8 +14,8 @@
 				</div>
 				<div class="field {{if .Err_Subject}}error{{end}}">
 					<label>{{ctx.Locale.Tr "repo.subject"}}</label>
-					<input name="subject" value="{{.Repository.GetSubject}}" maxlength="255">
-					<span class="help">{{ctx.Locale.Tr "repo.subject_helper"}}</span>
+					<input name="subject" value="{{.Repository.GetSubject}}" maxlength="255" readonly disabled>
+					<span class="help">{{ctx.Locale.Tr "repo.subject_cannot_be_modified"}}</span>
 				</div>
 				<div class="inline field">
 					<label>{{ctx.Locale.Tr "repo.repo_size"}}</label>

--- a/templates/shared/subject/list.tmpl
+++ b/templates/shared/subject/list.tmpl
@@ -1,0 +1,48 @@
+<div class="flex-list">
+	{{if .Keyword}}
+		<div class="tw-font-bold tw-text-base tw-mb-4">
+			{{ctx.Locale.Tr "explore.search_results_for" .Keyword}}
+		</div>
+	{{end}}
+	{{range .Subjects}}
+		<div class="flex-item">
+			<div class="flex-item-leading">
+				{{svg "octicon-book" 24}}
+			</div>
+			<div class="flex-item-main">
+				<div class="flex-item-header">
+					<div class="flex-item-title">
+						<a class="text primary name" href="/subject/{{PathEscapeSegments .Name}}">{{.Name}}</a>
+					</div>
+					<div class="flex-item-trailing muted-links">
+						{{if gt .RootRepoCount 0}}
+							<span class="flex-text-inline" data-tooltip-content="{{ctx.Locale.Tr "explore.subject.root_repositories"}}">
+								{{svg "octicon-repo" 16}}
+								<span>{{.RootRepoCount}}</span>
+							</span>
+						{{end}}
+						{{if gt .RepoCount .RootRepoCount}}
+							<span class="flex-text-inline" data-tooltip-content="{{ctx.Locale.Tr "explore.subject.total_repositories"}}">
+								{{svg "octicon-repo-forked" 16}}
+								<span>{{.RepoCount}}</span>
+							</span>
+						{{end}}
+					</div>
+				</div>
+				<div class="flex-item-body">
+					<span class="text small muted">
+						{{ctx.Locale.Tr "explore.subject.created"}} {{DateUtils.TimeSince .CreatedUnix}}
+						{{if ne .CreatedUnix .UpdatedUnix}}
+							· {{ctx.Locale.Tr "explore.subject.updated"}} {{DateUtils.TimeSince .UpdatedUnix}}
+						{{end}}
+					</span>
+				</div>
+			</div>
+		</div>
+	{{else}}
+		<div>
+			{{ctx.Locale.Tr "search.no_results"}}
+		</div>
+	{{end}}
+</div>
+

--- a/templates/shared/subject/search.tmpl
+++ b/templates/shared/subject/search.tmpl
@@ -1,0 +1,25 @@
+<div class="ui small secondary filter menu">
+	<form id="subject-search-form" class="ui form ignore-dirty tw-flex-1 tw-flex tw-items-center tw-gap-x-2">
+		<div class="ui small fluid action input tw-flex-1 tw-my-4">
+			{{template "shared/search/input" dict "Value" .Keyword "Placeholder" (ctx.Locale.Tr "search.subject_kind")}}
+			{{template "shared/search/button"}}
+		</div>
+		<!-- Sort -->
+		<div class="item ui small dropdown jump">
+			<div style="transform: rotate(90deg) !important;">
+				{{svg "octicon-arrow-switch" 14 "dropdown icon tw-mt-1 tw-rotate-90"}}
+			</div>
+			<span class="text">{{ctx.Locale.Tr "repo.issues.filter_sort"}}</span>
+			{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+			<div class="menu">
+				<label class="{{if eq .SortType "alphabetically"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "alphabetically"}}checked{{end}} value="alphabetically"> {{ctx.Locale.Tr "repo.issues.label.filter_sort.alphabetically"}}</label>
+				<label class="{{if eq .SortType "reversealphabetically"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "reversealphabetically"}}checked{{end}} value="reversealphabetically"> {{ctx.Locale.Tr "repo.issues.label.filter_sort.reverse_alphabetically"}}</label>
+				<label class="{{if eq .SortType "newest"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "newest"}}checked{{end}} value="newest"> {{ctx.Locale.Tr "repo.issues.filter_sort.latest"}}</label>
+				<label class="{{if eq .SortType "oldest"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "oldest"}}checked{{end}} value="oldest"> {{ctx.Locale.Tr "repo.issues.filter_sort.oldest"}}</label>
+				<label class="{{if eq .SortType "recentupdate"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "recentupdate"}}checked{{end}} value="recentupdate"> {{ctx.Locale.Tr "repo.issues.filter_sort.recentupdate"}}</label>
+				<label class="{{if eq .SortType "leastupdate"}}active {{end}}item"><input hidden type="radio" name="sort" {{if eq .SortType "leastupdate"}}checked{{end}} value="leastupdate"> {{ctx.Locale.Tr "repo.issues.filter_sort.leastupdate"}}</label>
+			</div>
+		</div>
+	</form>
+</div>
+

--- a/tests/integration/explore_subjects_test.go
+++ b/tests/integration/explore_subjects_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 okTurtles Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/tests"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExploreSubjects(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	// Create test subjects
+	subject1, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject Alpha")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject1)
+
+	subject2, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject Beta")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject2)
+
+	// Test basic page load
+	req := NewRequest(t, "GET", "/explore/articles")
+	resp := MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, http.StatusOK, resp.Code)
+
+	// Test search functionality
+	req = NewRequest(t, "GET", "/explore/articles?q=Alpha")
+	resp = MakeRequest(t, req, http.StatusOK)
+	respStr := resp.Body.String()
+	assert.Contains(t, respStr, `value="Alpha"`)
+
+	// Test sorting
+	req = NewRequest(t, "GET", "/explore/articles?sort=alphabetically")
+	resp = MakeRequest(t, req, http.StatusOK)
+	respStr = resp.Body.String()
+	assert.Contains(t, respStr, `value="alphabetically"`)
+
+	// Test pagination
+	req = NewRequest(t, "GET", "/explore/articles?page=1")
+	resp = MakeRequest(t, req, http.StatusOK)
+	assert.Equal(t, http.StatusOK, resp.Code)
+}
+
+func TestExploreSubjectsSorting(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	// Test all sort options
+	sortOptions := []string{
+		"alphabetically",
+		"reversealphabetically",
+		"newest",
+		"oldest",
+		"recentupdate",
+		"leastupdate",
+	}
+
+	for _, sortType := range sortOptions {
+		req := NewRequest(t, "GET", "/explore/articles?sort="+sortType)
+		resp := MakeRequest(t, req, http.StatusOK)
+		assert.Equal(t, http.StatusOK, resp.Code, "Sort type %s should work", sortType)
+	}
+}
+


### PR DESCRIPTION
- [x] add subject table fixtures for SubjectID foreign key testing
- [x] remove deprecated Subject string field from Repository model
- [x] update services to use SubjectID
- [x] resolve SQL ambiguity in repository search with subject
- [x] update repository tests for SubjectID implementation
- [x] add Subject model and database migrations
- [x] make subject relational field read-only
- [x] load SubjectRelation in repository context middleware
- [x] load SubjectRelation in RepoAssignmentByName middleware
- [x] revert repo/search_name template to use .Name instead of .GetSubject
- [x] fork hierarchy detection and contributor counts
- [x] add subject-based URL routing for repositories
- [x] list subjects by default

@pieer you might need to run `make clean` again in order to detect the new templates:
```
templates/explore/subjects.tmpl
templates/shared/subject/search.tmpl
templates/shared/subject/list.tmpl
custom/templates/explore/subjects.tmpl
custom/templates/shared/subject/search.tmpl
custom/templates/shared/subject/list.tmpl
```
