### PR TITLE
Subject: add slug-based uniqueness for race condition prevention

### DIFF
--- a/models/fixtures/subject.yml
+++ b/models/fixtures/subject.yml
@@ -1,12 +1,14 @@
 -
   id: 1
   name: example-subject
+  slug: example-subject
   created_unix: 1588800000
   updated_unix: 1588800000
 
 -
   id: 2
   name: another-subject
+  slug: another-subject
   created_unix: 1588800000
   updated_unix: 1588800000
 

--- a/models/migrations/custom/v1_25_custom/v326.go
+++ b/models/migrations/custom/v1_25_custom/v326.go
@@ -1,0 +1,234 @@
+// Copyright 2025 okTurtles Foundation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package v1_25_custom //nolint
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+	"xorm.io/xorm"
+)
+
+// generateSlugFromName creates a URL-safe slug from a subject display name
+// This is a copy of the function from models/repo/subject.go for use in migration
+func generateSlugFromName(name string) string {
+	// Normalize Unicode (NFD = decompose accents)
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	normalized, _, _ := transform.String(t, name)
+
+	// Convert to lowercase
+	slug := strings.ToLower(normalized)
+
+	// Replace underscores with hyphens
+	slug = strings.ReplaceAll(slug, "_", "-")
+
+	// Replace spaces with hyphens
+	slug = strings.ReplaceAll(slug, " ", "-")
+
+	// Remove all characters except alphanumeric and hyphens
+	reg := regexp.MustCompile(`[^a-z0-9-]+`)
+	slug = reg.ReplaceAllString(slug, "")
+
+	// Replace multiple consecutive hyphens with a single hyphen
+	reg = regexp.MustCompile(`-+`)
+	slug = reg.ReplaceAllString(slug, "-")
+
+	// Trim hyphens from start and end
+	slug = strings.Trim(slug, "-")
+
+	// If slug is empty after processing, use a default
+	if slug == "" {
+		slug = "subject"
+	}
+
+	// Limit length to 100 characters
+	if len(slug) > 100 {
+		slug = slug[:100]
+		// Trim any trailing hyphen that might have been created by truncation
+		slug = strings.TrimRight(slug, "-")
+	}
+
+	return slug
+}
+
+func AddSubjectSlugColumn(x *xorm.Engine) error {
+	// Define a temporary struct for the subject table
+	type Subject struct {
+		ID   int64  `xorm:"pk autoincr"`
+		Name string `xorm:"VARCHAR(255) NOT NULL"`
+		Slug string `xorm:"VARCHAR(255)"`
+	}
+
+	// Add slug column (without UNIQUE constraint initially)
+	if err := x.Sync(new(Subject)); err != nil {
+		return fmt.Errorf("failed to add slug column: %w", err)
+	}
+
+	// Generate slugs for all existing subjects
+	// Note: For large datasets (>10k subjects), consider batch processing
+	var subjects []Subject
+	if err := x.Table("subject").Find(&subjects); err != nil {
+		return fmt.Errorf("failed to fetch existing subjects: %w", err)
+	}
+
+	fmt.Printf("Migration v326: Processing %d existing subjects...\n", len(subjects))
+
+	// Pre-migration validation - check for potential slug collisions
+	slugPreview := make(map[string][]string) // slug -> list of names
+	for _, subject := range subjects {
+		slug := generateSlugFromName(subject.Name)
+		slugPreview[slug] = append(slugPreview[slug], subject.Name)
+	}
+
+	// Report potential collisions before making changes
+	potentialCollisions := 0
+	for slug, names := range slugPreview {
+		if len(names) > 1 {
+			potentialCollisions++
+			fmt.Printf("  WARNING: Multiple subjects will share slug '%s':\n", slug)
+			for _, name := range names {
+				fmt.Printf("    - '%s'\n", name)
+			}
+		}
+	}
+
+	if potentialCollisions > 0 {
+		fmt.Printf("Migration v326: Found %d slug collisions. These will be resolved by appending numeric suffixes.\n", potentialCollisions)
+	}
+
+	// Generate and assign slugs
+	usedSlugs := make(map[string]int)
+	collisionCount := 0
+
+	for i := range subjects {
+		baseSlug := generateSlugFromName(subjects[i].Name)
+		slug := baseSlug
+
+		// Handle slug collisions by appending a number
+		if count, exists := usedSlugs[slug]; exists {
+			usedSlugs[slug] = count + 1
+			slug = fmt.Sprintf("%s-%d", baseSlug, count+1)
+			collisionCount++
+			fmt.Printf("  Assigning slug '%s' to subject '%s' (ID: %d)\n",
+				slug, subjects[i].Name, subjects[i].ID)
+		} else {
+			usedSlugs[slug] = 1
+		}
+
+		subjects[i].Slug = slug
+
+		// Update the subject with the generated slug
+		if _, err := x.ID(subjects[i].ID).Cols("slug").Update(&subjects[i]); err != nil {
+			return fmt.Errorf("failed to update subject %d ('%s') with slug '%s': %w",
+				subjects[i].ID, subjects[i].Name, slug, err)
+		}
+	}
+
+	if collisionCount > 0 {
+		fmt.Printf("Migration v326: Resolved %d slug collisions by appending numeric suffixes\n", collisionCount)
+	}
+	fmt.Printf("Migration v326: Successfully generated slugs for all %d subjects\n", len(subjects))
+
+	// Verify all subjects have slugs before adding constraints
+	var subjectsWithoutSlug int64
+	subjectsWithoutSlug, err := x.Table("subject").Where("slug IS NULL OR slug = ''").Count()
+	if err != nil {
+		return fmt.Errorf("failed to verify slug generation: %w", err)
+	}
+	if subjectsWithoutSlug > 0 {
+		return fmt.Errorf("migration safety check failed: %d subjects still have empty slugs", subjectsWithoutSlug)
+	}
+
+	// Add UNIQUE and NOT NULL constraints to slug column
+	// This is database-specific
+	sess := x.NewSession()
+	defer sess.Close()
+
+	if err := sess.Begin(); err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	// Get database type
+	dialect := x.Dialect().URI().DBType
+
+	switch dialect {
+	case "mysql":
+		// MySQL: Modify column to add UNIQUE and NOT NULL
+		if _, err := sess.Exec("ALTER TABLE `subject` MODIFY COLUMN `slug` VARCHAR(255) NOT NULL"); err != nil {
+			_ = sess.Rollback()
+			return fmt.Errorf("failed to add NOT NULL constraint to slug: %w", err)
+		}
+		if _, err := sess.Exec("ALTER TABLE `subject` ADD UNIQUE INDEX `UQE_subject_slug` (`slug`)"); err != nil {
+			_ = sess.Rollback()
+			return fmt.Errorf("failed to add UNIQUE constraint to slug: %w", err)
+		}
+
+	case "postgres":
+		// PostgreSQL: Alter column and add constraint
+		if _, err := sess.Exec(`ALTER TABLE "subject" ALTER COLUMN "slug" SET NOT NULL`); err != nil {
+			_ = sess.Rollback()
+			return fmt.Errorf("failed to add NOT NULL constraint to slug: %w", err)
+		}
+		if _, err := sess.Exec(`ALTER TABLE "subject" ADD CONSTRAINT "UQE_subject_slug" UNIQUE ("slug")`); err != nil {
+			_ = sess.Rollback()
+			return fmt.Errorf("failed to add UNIQUE constraint to slug: %w", err)
+		}
+
+	case "sqlite3":
+		// SQLite: Need to recreate the table with the constraint
+		// This is more complex, but we can use a workaround by creating a unique index
+		if _, err := sess.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS "UQE_subject_slug" ON "subject" ("slug")`); err != nil {
+			_ = sess.Rollback()
+			return fmt.Errorf("failed to add UNIQUE constraint to slug: %w", err)
+		}
+
+	case "mssql":
+		// MSSQL: Alter column and add constraint
+		if _, err := sess.Exec(`ALTER TABLE [subject] ALTER COLUMN [slug] VARCHAR(255) NOT NULL`); err != nil {
+			_ = sess.Rollback()
+			return fmt.Errorf("failed to add NOT NULL constraint to slug: %w", err)
+		}
+		if _, err := sess.Exec(`ALTER TABLE [subject] ADD CONSTRAINT [UQE_subject_slug] UNIQUE ([slug])`); err != nil {
+			_ = sess.Rollback()
+			return fmt.Errorf("failed to add UNIQUE constraint to slug: %w", err)
+		}
+
+	default:
+		_ = sess.Rollback()
+		return fmt.Errorf("unsupported database type: %s", dialect)
+	}
+
+	// Remove UNIQUE constraint from name column (if it exists)
+	switch dialect {
+	case "mysql":
+		// Try to drop the unique index on name (ignore error if it doesn't exist)
+		_, _ = sess.Exec("ALTER TABLE `subject` DROP INDEX `UQE_subject_name`")
+
+	case "postgres":
+		// Try to drop the unique constraint on name (ignore error if it doesn't exist)
+		_, _ = sess.Exec(`ALTER TABLE "subject" DROP CONSTRAINT IF EXISTS "UQE_subject_name"`)
+
+	case "sqlite3":
+		// Try to drop the unique index on name (ignore error if it doesn't exist)
+		_, _ = sess.Exec(`DROP INDEX IF EXISTS "UQE_subject_name"`)
+
+	case "mssql":
+		// Try to drop the unique constraint on name (ignore error if it doesn't exist)
+		_, _ = sess.Exec(`ALTER TABLE [subject] DROP CONSTRAINT IF EXISTS [UQE_subject_name]`)
+	}
+
+	if err := sess.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	fmt.Printf("Migration v326: Successfully added UNIQUE constraint to slug column\n")
+	fmt.Printf("Migration v326: Migration completed successfully!\n")
+
+	return nil
+}

--- a/models/migrations/migrations.go
+++ b/models/migrations/migrations.go
@@ -400,6 +400,7 @@ func prepareMigrationTasks() []*migration {
 		newMigration(323, "Forkana: add subject to repository table", v1_25_custom.AddSubjectToRepository),
 		newMigration(324, "Forkana: create subjects table and populate with existing data", v1_25_custom.CreateSubjectsTable),
 		newMigration(325, "Forkana: add subject_id foreign key to repository table", v1_25_custom.AddSubjectForeignKeyToRepository),
+		newMigration(326, "Forkana: add slug column to subjects table", v1_25_custom.AddSubjectSlugColumn),
 	}
 	return preparedMigrations
 }

--- a/models/repo/subject_test.go
+++ b/models/repo/subject_test.go
@@ -4,6 +4,7 @@
 package repo_test
 
 import (
+	"sync"
 	"testing"
 
 	repo_model "code.gitea.io/gitea/models/repo"
@@ -162,4 +163,291 @@ func TestDeleteSubjectInUse(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, repo_model.IsErrSubjectInUse(err))
 }
+
+// TestGenerateSlugFromName tests the slug generation function with various inputs
+func TestGenerateSlugFromName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple lowercase",
+			input:    "the moon",
+			expected: "the-moon",
+		},
+		{
+			name:     "Capitalized",
+			input:    "The Moon",
+			expected: "the-moon",
+		},
+		{
+			name:     "With exclamation",
+			input:    "the moon!",
+			expected: "the-moon",
+		},
+		{
+			name:     "With question mark",
+			input:    "El Camiño?",
+			expected: "el-camino",
+		},
+		{
+			name:     "With accents",
+			input:    "Café Français",
+			expected: "cafe-francais",
+		},
+		{
+			name:     "With special characters",
+			input:    "Hello@World#2024!",
+			expected: "helloworld2024",
+		},
+		{
+			name:     "With underscores",
+			input:    "hello_world_test",
+			expected: "hello-world-test",
+		},
+		{
+			name:     "Multiple spaces",
+			input:    "hello   world",
+			expected: "hello-world",
+		},
+		{
+			name:     "Leading/trailing spaces",
+			input:    "  hello world  ",
+			expected: "hello-world",
+		},
+		{
+			name:     "Unicode characters",
+			input:    "Zürich",
+			expected: "zurich",
+		},
+		{
+			name:     "Empty string",
+			input:    "",
+			expected: "subject",
+		},
+		{
+			name:     "Only special characters",
+			input:    "!!!???",
+			expected: "subject",
+		},
+		{
+			name:     "Mixed case with numbers",
+			input:    "Test123Subject",
+			expected: "test123subject",
+		},
+		{
+			name:     "Multiple hyphens",
+			input:    "hello---world",
+			expected: "hello-world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := repo_model.GenerateSlugFromName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestCreateSubject_UniqueSlug tests that CreateSubject enforces unique slugs
+func TestCreateSubject_UniqueSlug(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create first subject
+	subject1, err := repo_model.CreateSubject(t.Context(), "The Moon")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject1)
+	assert.Equal(t, "The Moon", subject1.Name)
+	assert.Equal(t, "the-moon", subject1.Slug)
+
+	// Try to create another subject with same slug (different display name)
+	_, err = repo_model.CreateSubject(t.Context(), "the moon!")
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectSlugAlreadyExists(err))
+
+	// Create subject with different slug should work
+	subject2, err := repo_model.CreateSubject(t.Context(), "The Sun")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject2)
+	assert.Equal(t, "The Sun", subject2.Name)
+	assert.Equal(t, "the-sun", subject2.Slug)
+}
+
+// TestGetOrCreateSubject_Slug tests that GetOrCreateSubject works with slug-based uniqueness
+func TestGetOrCreateSubject_Slug(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create first subject
+	subject1, err := repo_model.GetOrCreateSubject(t.Context(), "The Moon")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject1)
+	assert.Equal(t, "The Moon", subject1.Name)
+	assert.Equal(t, "the-moon", subject1.Slug)
+
+	// Get same subject with different display name but same slug
+	subject2, err := repo_model.GetOrCreateSubject(t.Context(), "the moon!")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject2)
+	assert.Equal(t, subject1.ID, subject2.ID, "Should return the same subject")
+	assert.Equal(t, "The Moon", subject2.Name, "Should keep original name")
+	assert.Equal(t, "the-moon", subject2.Slug)
+
+	// Create different subject
+	subject3, err := repo_model.GetOrCreateSubject(t.Context(), "The Sun")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject3)
+	assert.NotEqual(t, subject1.ID, subject3.ID, "Should be different subject")
+	assert.Equal(t, "The Sun", subject3.Name)
+	assert.Equal(t, "the-sun", subject3.Slug)
+}
+
+// TestGetSubjectBySlug tests getting a subject by its slug
+func TestGetSubjectBySlug(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create a subject
+	subject1, err := repo_model.GetOrCreateSubject(t.Context(), "Test Subject Slug")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject1)
+
+	// Get by slug
+	subject2, err := repo_model.GetSubjectBySlug(t.Context(), "test-subject-slug")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject2)
+	assert.Equal(t, subject1.ID, subject2.ID)
+	assert.Equal(t, subject1.Name, subject2.Name)
+	assert.Equal(t, subject1.Slug, subject2.Slug)
+
+	// Test with non-existent slug
+	_, err = repo_model.GetSubjectBySlug(t.Context(), "non-existent-slug")
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrSubjectNotExist(err))
+}
+
+
+// TestCreateSubject_RaceCondition tests concurrent subject creation
+func TestCreateSubject_RaceCondition(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	errors := make([]error, numGoroutines)
+	subjects := make([]*repo_model.Subject, numGoroutines)
+
+	// Try to create the same subject concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			subject, err := repo_model.CreateSubject(t.Context(), "Concurrent Test Subject")
+			errors[index] = err
+			subjects[index] = subject
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Count successes and failures
+	successCount := 0
+	failureCount := 0
+	var successfulSubject *repo_model.Subject
+
+	for i := 0; i < numGoroutines; i++ {
+		if errors[i] == nil {
+			successCount++
+			successfulSubject = subjects[i]
+		} else {
+			failureCount++
+			assert.True(t, repo_model.IsErrSubjectSlugAlreadyExists(errors[i]),
+				"Error should be ErrSubjectSlugAlreadyExists, got: %v", errors[i])
+		}
+	}
+
+	// Exactly one should succeed
+	assert.Equal(t, 1, successCount, "Exactly one goroutine should succeed")
+	assert.Equal(t, numGoroutines-1, failureCount, "All other goroutines should fail")
+	assert.NotNil(t, successfulSubject)
+	assert.Equal(t, "concurrent-test-subject", successfulSubject.Slug)
+}
+
+// TestGetOrCreateSubject_RaceCondition tests concurrent GetOrCreate operations
+func TestGetOrCreateSubject_RaceCondition(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	const numGoroutines = 10
+	var wg sync.WaitGroup
+	subjects := make([]*repo_model.Subject, numGoroutines)
+	errors := make([]error, numGoroutines)
+
+	// Try to get or create the same subject concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			subject, err := repo_model.GetOrCreateSubject(t.Context(), "Concurrent GetOrCreate Test")
+			subjects[index] = subject
+			errors[index] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All should succeed
+	for i := 0; i < numGoroutines; i++ {
+		assert.NoError(t, errors[i], "GetOrCreateSubject should not fail")
+		assert.NotNil(t, subjects[i])
+	}
+
+	// All should return the same subject ID
+	firstID := subjects[0].ID
+	for i := 1; i < numGoroutines; i++ {
+		assert.Equal(t, firstID, subjects[i].ID, "All goroutines should get the same subject")
+		assert.Equal(t, "concurrent-getorcreate-test", subjects[i].Slug)
+	}
+}
+
+// TestMultipleRepositoriesSameSubject tests that multiple repositories can reference the same subject
+func TestMultipleRepositoriesSameSubject(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+
+	// Create a subject
+	subject, err := repo_model.GetOrCreateSubject(t.Context(), "Shared Subject")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Get two different repositories
+	repo1, err := repo_model.GetRepositoryByID(t.Context(), 1)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo1)
+
+	repo2, err := repo_model.GetRepositoryByID(t.Context(), 2)
+	assert.NoError(t, err)
+	assert.NotNil(t, repo2)
+
+	// Assign the same subject to both repositories
+	repo1.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsWithAutoTime(t.Context(), repo1, "subject_id")
+	assert.NoError(t, err)
+
+	repo2.SubjectID = subject.ID
+	err = repo_model.UpdateRepositoryColsWithAutoTime(t.Context(), repo2, "subject_id")
+	assert.NoError(t, err)
+
+	// Verify both repositories have the same subject
+	err = repo1.LoadSubject(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, subject.ID, repo1.SubjectRelation.ID)
+
+	err = repo2.LoadSubject(t.Context())
+	assert.NoError(t, err)
+	assert.Equal(t, subject.ID, repo2.SubjectRelation.ID)
+
+	// Count repositories with this subject
+	count, err := repo_model.CountRepositoriesBySubject(t.Context(), subject.ID)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, count, int64(2), "At least 2 repositories should have this subject")
+}
+
 


### PR DESCRIPTION
Add slug field to Subject model with UNIQUE database constraint to prevent race conditions in concurrent subject creation. Display names can now contain special characters while slugs enforce global uniqueness.