### PR TITLE
Add fork graph cache key

### DIFF
--- a/routers/api/v1/repo/fork_graph_test.go
+++ b/routers/api/v1/repo/fork_graph_test.go
@@ -204,6 +204,25 @@ func TestForkGraphCacheKey(t *testing.T) {
 	assert.NotEqual(t, key1, key3)
 }
 
+func TestForkGraphCacheKeyIncludesVersion(t *testing.T) {
+	params := ForkGraphParams{
+		IncludeContributors: true,
+		ContributorDays:     90,
+		MaxDepth:            10,
+		Sort:                "updated",
+		Page:                1,
+		Limit:               50,
+	}
+
+	key := getCacheKey(1, params, 1)
+
+	// Verify cache key includes the version
+	assert.Contains(t, key, forkGraphCacheVersion, "Cache key should include version for cache invalidation")
+
+	// Verify cache key format: fork_graph:{version}:{repoID}:{paramsHash}:{userID}
+	assert.Contains(t, key, "fork_graph:"+forkGraphCacheVersion+":", "Cache key should start with fork_graph:{version}:")
+}
+
 func TestForkGraphDefaults(t *testing.T) {
 	params := ForkGraphParams{}
 	params.setDefaults()


### PR DESCRIPTION
Increments whenever the fork graph logic, data structure, or API response format changes. This allows automatic cache invalidation across deployments.

### Rationale:
- v2 was chosen as the initial version because okTurtles/forkana/issues/9 was recently fixed, representing a significant change in fork graph logic;
- Version history is documented inline for future maintainers;
- Clear guidelines on when to increment the version;

### Key Changes:
- Version is now the first component in the cache key
- Comprehensive documentation explains each component
- Clear guidelines on when to increment the version
- Cache key format: `fork_graph:{version}:{repoID}:{paramsHash}:{userID}`

### Future Version Increments (when to increment `forkGraphCacheVersion`):

**1. Algorithm Changes:**

- Fork graph traversal logic modified
- Cycle detection behavior changed
- Sorting or filtering logic updated
- Data Structure Changes:

**2. ForkGraphResponse structure modified**

- ForkNode structure modified
- New fields added to response

**3. Permission Logic Changes:**

- Access control logic modified
- Private fork visibility rules changed

**4. Bug Fixes:**

- Fixes that affect cached data correctness
- Fixes that change graph structure