### PR TITLE
Fix #7: Secure fork button with proper form navigation

### DIFF
--- a/custom/templates/shared/repo/article.tmpl
+++ b/custom/templates/shared/repo/article.tmpl
@@ -65,10 +65,19 @@
                         {{if .IsArticleModeEdit}}
                             <div class="tw-flex tw-items-center tw-justify-between tw-mb-4">
                                 <div class="tw-flex tw-items-center tw-gap-2">
-                                    <button type="button" id="fork-button" class="ui button{{if not .IsSigned}} disabled{{end}}" data-repo-link="{{.RepoLink}}">
-                                        {{svg "octicon-repo-forked" 16 "tw-mr-1"}}
-                                        Fork
-                                    </button>
+                                    {{if .IsSigned}}
+                                        <form id="fork-form" action="{{.RepoLink}}/fork" method="get" style="display: inline;">
+                                            <button type="submit" class="ui button">
+                                                {{svg "octicon-repo-forked" 16 "tw-mr-1"}}
+                                                Fork
+                                            </button>
+                                        </form>
+                                    {{else}}
+                                        <button type="button" class="ui button disabled">
+                                            {{svg "octicon-repo-forked" 16 "tw-mr-1"}}
+                                            Fork
+                                        </button>
+                                    {{end}}
                                     <button type="button" id="submit-changes-button" class="ui primary button{{if not .IsSigned}} disabled{{end}}">
                                         {{svg "octicon-check" 16 "tw-mr-1"}}
                                         Submit Changes

--- a/web_src/js/features/article-editor.ts
+++ b/web_src/js/features/article-editor.ts
@@ -17,17 +17,8 @@ export function initArticleEditor() {
       hideModeSwitch: false  // Allow mode switching
     });
 
-
-    // Handle Fork button
-    const forkButton = document.getElementById('fork-button');
-    if (forkButton && !forkButton.classList.contains('disabled')) {
-      forkButton.addEventListener('click', async () => {
-        const repoLink = forkButton.getAttribute('data-repo-link');
-        if (repoLink && confirm('Do you want to fork this repository?')) {
-          window.location.href = `${repoLink}/fork`;
-        }
-      });
-    }
+    // Fork button is now handled by a form in the template with proper navigation
+    // No JavaScript handler needed - the form submission navigates to the fork page
 
     // Handle Submit Changes button
     const submitButton = document.getElementById('submit-changes-button');


### PR DESCRIPTION
Replaced JavaScript redirect with native HTML form:
- Form uses GET to navigate to fork page (standard Gitea pattern)
- Proper authentication check in template  
- Removed unnecessary JavaScript handler
- Follows same pattern as Gitea's main fork button

## Benefits

✅ Security: No client-side URL manipulation
✅ Simplicity: Native browser form handling
✅ Best Practices: Matches Gitea's standard implementation

The fork page itself has CSRF protection on the actual POST request.

Fixes okTurtles/forkana#7