### PR TITLE
Fix #13: Add proper null check for ReadmeLastCommit.Committer

### DIFF
--- a/custom/templates/shared/repo/article.tmpl
+++ b/custom/templates/shared/repo/article.tmpl
@@ -26,7 +26,7 @@
                     {{svg "octicon-person" 16 "tw-mr-1"}}
                     {{.ReadmeContributorCount}} {{if eq .ReadmeContributorCount 1}}contributor{{else}}contributors{{end}}
                 </span>
-                {{if .ReadmeLastCommit}}
+                {{if and .ReadmeLastCommit .ReadmeLastCommit.Committer}}
                     <span class="pill">
                         {{svg "octicon-sync" 16 "tw-mr-1"}}
                         Updated {{DateUtils.TimeSince .ReadmeLastCommit.Committer.When}}


### PR DESCRIPTION
- Added nested null check using 'and' template function
- Prevents potential nil pointer access when Committer is nil
- Changed condition from just checking ReadmeLastCommit to also checking Committer field
- Ensures safe access to .ReadmeLastCommit.Committer.When

Bug fix:
- Previously: {{if .ReadmeLastCommit}} only checked outer object
- Now: {{if and .ReadmeLastCommit .ReadmeLastCommit.Committer}} checks both
- Prevents runtime error if Committer field is nil

Fixes okTurtles/forkana#13