### PR TITLE
Fix #5: Document automatic XSS protection in templates

### DIFF
--- a/custom/templates/shared/repo/edit.tmpl
+++ b/custom/templates/shared/repo/edit.tmpl
@@ -17,8 +17,10 @@
                         {{svg "octicon-repo-forked" 14 "tw-mr-1"}}
                         Forked of:
                         {{if .Repository.BaseRepo}}
+                            {{/* Go html/template automatically HTML-escapes these strings to prevent XSS */}}
                             <a class="tw-ml-1" href="{{.Repository.BaseRepo.Link}}">{{.Repository.BaseRepo.OwnerName}} / {{.Repository.BaseRepo.Name}}</a>
                         {{else}}
+                            {{/* Go html/template automatically HTML-escapes these strings to prevent XSS */}}
                             <span class="tw-ml-1">{{.Repository.Owner.Name}} / {{.Repository.Name}}</span>
                         {{end}}
                     </span>

--- a/custom/templates/shared/repo/history.tmpl
+++ b/custom/templates/shared/repo/history.tmpl
@@ -16,8 +16,10 @@
                     {{svg "octicon-repo-forked" 14 "tw-mr-1"}}
                     Forked of:
                     {{if .Repository.BaseRepo}}
+                        {{/* Go html/template automatically HTML-escapes these strings to prevent XSS */}}
                         <a class="tw-ml-1" href="{{.Repository.BaseRepo.Link}}">{{.Repository.BaseRepo.OwnerName}} / {{.Repository.BaseRepo.Name}}</a>
                     {{else}}
+                        {{/* Go html/template automatically HTML-escapes these strings to prevent XSS */}}
                         <span class="tw-ml-1">{{.Repository.Owner.Name}} / {{.Repository.Name}}</span>
                     {{end}}
                 </span>

--- a/custom/templates/shared/repo/read.tmpl
+++ b/custom/templates/shared/repo/read.tmpl
@@ -17,8 +17,10 @@
                         {{svg "octicon-repo-forked" 14 "tw-mr-1"}}
                         Forked of:
                         {{if .Repository.BaseRepo}}
+                            {{/* Go html/template automatically HTML-escapes these strings to prevent XSS */}}
                             <a class="tw-ml-1" href="{{.Repository.BaseRepo.Link}}">{{.Repository.BaseRepo.OwnerName}} / {{.Repository.BaseRepo.Name}}</a>
                         {{else}}
+                            {{/* Go html/template automatically HTML-escapes these strings to prevent XSS */}}
                             <span class="tw-ml-1">{{.Repository.Owner.Name}} / {{.Repository.Name}}</span>
                         {{end}}
                     </span>


### PR DESCRIPTION
- Added documentation comments to clarify XSS protection
- Go's html/template package automatically HTML-escapes all variables
- OwnerName, Name, and similar string fields are auto-escaped by default
- No explicit escaping needed unless fields are template.HTML type

Technical explanation:
- Gitea uses Go's html/template (not text/template)
- All {{.Variable}} outputs are automatically HTML-escaped
- Only template.HTML types bypass escaping (used for trusted content)
- Repository.OwnerName and Repository.Name are plain strings, thus safe

This is NOT a vulnerability:
- Go template engine provides context-aware auto-escaping
- Same protection mechanism used throughout Gitea
- No additional escaping functions needed for these fields

Files updated:
- custom/templates/shared/repo/read.tmpl
- custom/templates/shared/repo/history.tmpl
- custom/templates/shared/repo/edit.tmpl

Fixes okTurtles/forkana#5