### PR TITLE
Auto-load subject in GetSubject method

### DIFF
--- a/custom/templates/explore/repo_history.tmpl
+++ b/custom/templates/explore/repo_history.tmpl
@@ -25,7 +25,7 @@
                             {{if gt $node.Level 2}}<span class="ui basic mini label">{{svg "octicon-git-branch" 12}}</span><span class="ui basic mini label">{{svg "octicon-git-branch" 12}}</span><span class="ui basic mini label">{{svg "octicon-git-branch" 12}}</span>{{end}}
                         {{end}}
 
-                        <a class="ui large text" href="/subject/{{$node.Repository.GetSubject}}">
+                        <a class="ui large text" href="/subject/{{$node.Repository.GetSubject ctx}}">
                             <strong>{{if $node.Repository.Owner}}{{$node.Repository.Owner.Name}}{{else}}unknown{{end}}/{{$node.Repository.Name}}</strong>
                         </a>
 
@@ -160,14 +160,14 @@
         {{if .IsRepoEmpty}}
             {{template "repo/empty" .}}
         {{else}}
-            {{ $subjectPath := printf "%s/subject/%s" AppSubUrl (PathEscapeSegments .Repository.GetSubject) }}
+            {{ $subjectPath := printf "%s/subject/%s" AppSubUrl (PathEscapeSegments (.Repository.GetSubject ctx)) }}
             <div id="repo-history-app"
                 class="history-view-app"
                 data-initial-view="{{.HistoryView}}"
                 data-initial-mode="{{if .ArticleMode}}{{.ArticleMode}}{{else}}read{{end}}"
                 data-initial-owner="{{.Repository.Owner.Name}}"
                 data-initial-repo="{{.Repository.Name}}"
-                data-initial-subject="{{.Repository.GetSubject}}"
+                data-initial-subject="{{.Repository.GetSubject ctx}}"
                 data-subject-url="{{$subjectPath}}"
                 data-bubble-url="{{QueryBuild $subjectPath "view" "bubble"}}"
                 data-table-url="{{QueryBuild $subjectPath "view" "table"}}"

--- a/custom/templates/repo/header.tmpl
+++ b/custom/templates/repo/header.tmpl
@@ -2,7 +2,7 @@
 {{with .Repository}}
 	<div class="ui container">
 		<div class="repo-header tw-flex tw-justify-center tw-pt-14 tw-pb-10">
-			<h1 class="tw-text-40">{{.GetSubject}}</h1>
+			<h1 class="tw-text-40">{{.GetSubject ctx}}</h1>
 			<!-- Does header need to be a link?
 				<a class="muted" href="{{$.RepoLink}}"></a>
 			-->
@@ -11,14 +11,14 @@
 {{end}}
 	<div class="ui container">
 		<overflow-menu class="ui secondary pointing menu">
-            <div class="overflow-menu-items tw-justify-center" id="subject-view-tabs" data-owner="{{.Repository.Owner.Name}}" data-subject="{{.Repository.GetSubject}}">
-                <a class="{{if .IsBubbleView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "bubble"}}" data-view="bubble">
+            <div class="overflow-menu-items tw-justify-center" id="subject-view-tabs" data-owner="{{.Repository.Owner.Name}}" data-subject="{{.Repository.GetSubject ctx}}">
+                <a class="{{if .IsBubbleView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (.Repository.GetSubject ctx)) "view" "bubble"}}" data-view="bubble">
 					{{svg "bubble"}} Bubble view
 				</a>
-                <a class="{{if .IsTableView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "table"}}" data-view="table">
+                <a class="{{if .IsTableView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (.Repository.GetSubject ctx)) "view" "table"}}" data-view="table">
 					{{svg "octicon-table"}} Table view
 				</a>
-                <a class="{{if .IsArticleView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl .Repository.GetSubject) "view" "article"}}" data-view="article" id="article-view-link">
+                <a class="{{if .IsArticleView}}active {{end}}item" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (.Repository.GetSubject ctx)) "view" "article"}}" data-view="article" id="article-view-link">
 					{{svg "octicon-file"}} Article view
 				</a>
 			</div>

--- a/custom/templates/shared/repo/article.tmpl
+++ b/custom/templates/shared/repo/article.tmpl
@@ -36,17 +36,17 @@
             <div class="tw-flex tw-items-center tw-gap-4" id="article-tabs">
                 <div class="ui top attached tabular menu tw-my-10 tw-gap-1">
                     <a class="{{if .IsArticleModeRead}}active {{end}}item"
-                        href="{{QueryBuild (printf "%s/article/%s/%s" AppSubUrl .Repository.Owner.Name .Repository.GetSubject) "view" "article" "mode" "read"}}"
+                        href="{{QueryBuild (printf "%s/article/%s/%s" AppSubUrl .Repository.Owner.Name (.Repository.GetSubject ctx)) "view" "article" "mode" "read"}}"
                         data-article-tab="read">
                         {{svg "octicon-book" 16}} Read
                     </a>
                     <a class="{{if .IsArticleModeEdit}}active {{end}}item"
-                        href="{{QueryBuild (printf "%s/article/%s/%s" AppSubUrl .Repository.Owner.Name .Repository.GetSubject) "view" "article" "mode" "edit"}}"
+                        href="{{QueryBuild (printf "%s/article/%s/%s" AppSubUrl .Repository.Owner.Name (.Repository.GetSubject ctx)) "view" "article" "mode" "edit"}}"
                         data-article-tab="edit">
                         {{svg "octicon-pencil" 16}} Edit
                     </a>
                     <a class="{{if .IsArticleModeHistory}}active {{end}}item"
-                        href="{{QueryBuild (printf "%s/article/%s/%s" AppSubUrl .Repository.Owner.Name .Repository.GetSubject) "view" "article" "mode" "history"}}"
+                        href="{{QueryBuild (printf "%s/article/%s/%s" AppSubUrl .Repository.Owner.Name (.Repository.GetSubject ctx)) "view" "article" "mode" "history"}}"
                         data-article-tab="history">
                         {{svg "octicon-history" 16}} History
                     </a>

--- a/custom/templates/shared/repo/bubble.tmpl
+++ b/custom/templates/shared/repo/bubble.tmpl
@@ -4,7 +4,7 @@
         class="history-bubble-root"
         data-owner="{{.Repository.Owner.Name}}"
         data-repo="{{.Repository.Name}}"
-        data-subject="{{.Repository.GetSubject}}"
+        data-subject="{{.Repository.GetSubject ctx}}"
         data-api-url="{{AppSubUrl}}/api/v1/repos/{{.Repository.Owner.Name}}/{{.Repository.Name}}/forks/graph">
     </div>
 </div>

--- a/custom/templates/shared/repo/list.tmpl
+++ b/custom/templates/shared/repo/list.tmpl
@@ -11,7 +11,7 @@
 			<div class="flex-item-main">
 				<div class="flex-item-header">
 					<div class="flex-item-title">
-						<a class="text primary name" href="{{.Link}}">{{.GetSubject}}</a>
+						<a class="text primary name" href="{{.Link}}">{{.GetSubject ctx}}</a>
 						<span class="label-list">
 							{{if .IsArchived}}
 								<span class="ui basic label">{{ctx.Locale.Tr "repo.desc.archived"}}</span>

--- a/custom/templates/shared/repo/table.tmpl
+++ b/custom/templates/shared/repo/table.tmpl
@@ -13,9 +13,9 @@
                         {{svg "octicon-triangle-down" 16 "tw-ml-1"}}
                         <div class="menu">
                         cona
-                            <a class="item history-table-sort" data-sort="most_contrib" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (PathEscapeSegments .Repository.GetSubject)) "view" "table" "sort" "most_contrib"}}">Most contributors</a>
-                            <a class="item history-table-sort" data-sort="least_contrib" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (PathEscapeSegments .Repository.GetSubject)) "view" "table" "sort" "least_contrib"}}">Least contributors</a>
-                            <a class="item history-table-sort" data-sort="latest" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (PathEscapeSegments .Repository.GetSubject)) "view" "table" "sort" "latest"}}">Latest edited</a>
+                            <a class="item history-table-sort" data-sort="most_contrib" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (PathEscapeSegments (.Repository.GetSubject ctx))) "view" "table" "sort" "most_contrib"}}">Most contributors</a>
+                            <a class="item history-table-sort" data-sort="least_contrib" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (PathEscapeSegments (.Repository.GetSubject ctx))) "view" "table" "sort" "least_contrib"}}">Least contributors</a>
+                            <a class="item history-table-sort" data-sort="latest" href="{{QueryBuild (printf "%s/subject/%s" AppSubUrl (PathEscapeSegments (.Repository.GetSubject ctx))) "view" "table" "sort" "latest"}}">Latest edited</a>
                         </div>
                     </div>
                 </div>
@@ -43,7 +43,7 @@
                         {{if .HistoryForkEntries}}
                         {{range $idx, $entry := .HistoryForkEntries}}
                         {{$repo := $entry.Repo}}
-                        <tr class="article-row" data-row="{{$idx}}" data-owner="{{$repo.OwnerName}}" data-subject="{{$repo.GetSubject}}" data-repo="{{$repo.Name}}">
+                        <tr class="article-row" data-row="{{$idx}}" data-owner="{{$repo.OwnerName}}" data-subject="{{$repo.GetSubject ctx}}" data-repo="{{$repo.Name}}">
                             <td>
                                 <div class="ui checkbox">
                                     <input type="checkbox" class="row-check">
@@ -55,7 +55,7 @@
                             <td>
                                 <div class="tw-flex tw-flex-col tw-gap-1">
                                     <span class="tw-font-semibold">{{$repo.OwnerName}}</span>
-                                    <span class="tw-text-xs tw-text-gray-500">{{$repo.GetSubject}}</span>
+                                    <span class="tw-text-xs tw-text-gray-500">{{$repo.GetSubject ctx}}</span>
                                 </div>
                             </td>
                             <td class="collapsing tw-text-right">
@@ -78,7 +78,7 @@
                                             {{end}}
                                         </div>
                                     </div>
-                                    <button type="button" class="ui button go-to-article" data-owner="{{$repo.OwnerName}}" data-subject="{{$repo.GetSubject}}" data-repo="{{$repo.Name}}">
+                                    <button type="button" class="ui button go-to-article" data-owner="{{$repo.OwnerName}}" data-subject="{{$repo.GetSubject ctx}}" data-repo="{{$repo.Name}}">
                                         View article
                                     </button>
                                 </div>

--- a/models/repo/search_sql_test.go
+++ b/models/repo/search_sql_test.go
@@ -104,7 +104,7 @@ func TestSubjectFieldSearchIntegration(t *testing.T) {
 		for _, repo := range repos {
 			assert.NotEmpty(t, repo.Name, "Repository should have a name")
 			// Subject can be accessed via GetSubject() method
-			_ = repo.GetSubject() // This should not panic
+			_ = repo.GetSubject(context.Background()) // This should not panic
 		}
 	}
 }

--- a/models/repo/subject_test.go
+++ b/models/repo/subject_test.go
@@ -104,7 +104,7 @@ func TestRepositoryLoadSubject(t *testing.T) {
 	assert.Equal(t, subject.Name, repo.SubjectRelation.Name)
 
 	// Test GetSubject method
-	assert.Equal(t, subject.Name, repo.GetSubject())
+	assert.Equal(t, subject.Name, repo.GetSubject(t.Context()))
 }
 
 func TestRepositoryGetSubjectFallback(t *testing.T) {
@@ -120,7 +120,7 @@ func TestRepositoryGetSubjectFallback(t *testing.T) {
 	repo.SubjectRelation = nil
 
 	// Should fall back to repository name
-	assert.Equal(t, repo.Name, repo.GetSubject())
+	assert.Equal(t, repo.Name, repo.GetSubject(t.Context()))
 }
 
 func TestDeleteSubject(t *testing.T) {

--- a/routers/api/v1/repo/repo.go
+++ b/routers/api/v1/repo/repo.go
@@ -711,7 +711,7 @@ func updateBasicProperties(ctx *context.APIContext, opts api.EditRepoOption) err
 	repo.LowerName = strings.ToLower(newRepoName)
 
 	// Subject cannot be edited after repository creation
-	if opts.Subject != nil && *opts.Subject != repo.GetSubject() {
+	if opts.Subject != nil && *opts.Subject != repo.GetSubject(ctx) {
 		err := fmt.Errorf("subject cannot be modified after repository creation")
 		ctx.APIError(http.StatusUnprocessableEntity, err)
 		return err

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -556,7 +556,7 @@ func SearchRepo(ctx *context.Context) {
 		results[i] = &repo_service.WebSearchRepository{
 			Repository: &api.Repository{
 				ID:       repo.ID,
-				Subject:  repo.GetSubject(),
+				Subject:  repo.GetSubject(ctx),
 				FullName: repo.FullName(),
 				Fork:     repo.IsFork,
 				Private:  repo.IsPrivate,

--- a/routers/web/repo/setting/setting.go
+++ b/routers/web/repo/setting/setting.go
@@ -206,7 +206,7 @@ func handleSettingsPostUpdate(ctx *context.Context) {
 	repo.LowerName = strings.ToLower(newRepoName)
 
 	// Subject cannot be edited after repository creation
-	if form.Subject != repo.GetSubject() {
+	if form.Subject != repo.GetSubject(ctx) {
 		ctx.Data["Err_Subject"] = true
 		ctx.RenderWithErr(ctx.Tr("repo.subject_cannot_be_modified"), tplSettingsOptions, &form)
 		return

--- a/routers/web/repo/setting/settings_test.go
+++ b/routers/web/repo/setting/settings_test.go
@@ -410,8 +410,8 @@ func TestRepositorySubjectLoaded(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify that GetSubject() returns the subject name, not the repo name
-	assert.Equal(t, "Test Subject for Settings", repo.GetSubject())
-	assert.NotEqual(t, repo.Name, repo.GetSubject())
+	assert.Equal(t, "Test Subject for Settings", repo.GetSubject(t.Context()))
+	assert.NotEqual(t, repo.Name, repo.GetSubject(t.Context()))
 
 	// Verify that SubjectRelation is properly loaded
 	assert.NotNil(t, repo.SubjectRelation)
@@ -445,8 +445,8 @@ func TestRepositorySubjectLoadedByName(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify that GetSubject() returns the subject name, not the repo name
-	assert.Equal(t, "Test Subject for History View", repo.GetSubject())
-	assert.NotEqual(t, repo.Name, repo.GetSubject())
+	assert.Equal(t, "Test Subject for History View", repo.GetSubject(t.Context()))
+	assert.NotEqual(t, repo.Name, repo.GetSubject(t.Context()))
 
 	// Verify that SubjectRelation is properly loaded
 	assert.NotNil(t, repo.SubjectRelation)

--- a/services/convert/repository.go
+++ b/services/convert/repository.go
@@ -195,7 +195,7 @@ func innerToRepo(ctx context.Context, repo *repo_model.Repository, permissionInR
 		ID:                            repo.ID,
 		Owner:                         ToUserWithAccessMode(ctx, repo.Owner, permissionInRepo.AccessMode),
 		Name:                          repo.Name,
-		Subject:                       repo.GetSubject(),
+		Subject:                       repo.GetSubject(ctx),
 		FullName:                      repo.FullName(),
 		Description:                   repo.Description,
 		Private:                       repo.IsPrivate,

--- a/templates/repo/settings/options.tmpl
+++ b/templates/repo/settings/options.tmpl
@@ -14,7 +14,7 @@
 				</div>
 				<div class="field {{if .Err_Subject}}error{{end}}">
 					<label>{{ctx.Locale.Tr "repo.subject"}}</label>
-					<input name="subject" value="{{.Repository.GetSubject}}" maxlength="255" readonly disabled>
+					<input name="subject" value="{{.Repository.GetSubject ctx}}" maxlength="255" readonly disabled>
 					<span class="help">{{ctx.Locale.Tr "repo.subject_cannot_be_modified"}}</span>
 				</div>
 				<div class="inline field">


### PR DESCRIPTION
* Refactor the GetSubject() method to automatically load the subject relation when needed, eliminating silent failures when SubjectRelation is not pre-loaded.
* Fix template rendering errors after GetSubject() refactoring: templates were calling .GetSubject without the required context.Context parameter.