### PR TITLE
Clarify error message in GetPublicRepositoryBySubject

### DIFF
--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -852,6 +852,27 @@ func (err ErrRepoNotExist) Unwrap() error {
 	return util.ErrNotExist
 }
 
+// ErrRepoWithSubjectNotExist represents a "RepoWithSubjectNotExist" kind of error.
+// This error is returned when no repository is found for a given subject.
+type ErrRepoWithSubjectNotExist struct {
+	Subject string
+}
+
+// IsErrRepoWithSubjectNotExist checks if an error is a ErrRepoWithSubjectNotExist.
+func IsErrRepoWithSubjectNotExist(err error) bool {
+	_, ok := err.(ErrRepoWithSubjectNotExist)
+	return ok
+}
+
+func (err ErrRepoWithSubjectNotExist) Error() string {
+	return fmt.Sprintf("repository with subject does not exist [subject: %s]", err.Subject)
+}
+
+// Unwrap unwraps this error as a ErrNotExist error
+func (err ErrRepoWithSubjectNotExist) Unwrap() error {
+	return util.ErrNotExist
+}
+
 // GetRepositoryByOwnerAndName returns the repository by given owner name and repo name
 func GetRepositoryByOwnerAndName(ctx context.Context, ownerName, repoName string) (*Repository, error) {
 	var repo Repository
@@ -926,7 +947,7 @@ func GetPublicRepositoryBySubject(ctx context.Context, subjectName string) (*Rep
 	if err != nil {
 		return nil, err
 	} else if !has {
-		return nil, ErrRepoNotExist{0, 0, "", subjectName}
+		return nil, ErrRepoWithSubjectNotExist{Subject: subjectName}
 	}
 
 	// Load the subject relation

--- a/models/repo/repo_subject_test.go
+++ b/models/repo/repo_subject_test.go
@@ -50,6 +50,21 @@ func TestGetPublicRepositoryBySubject_NotFound(t *testing.T) {
 	assert.True(t, repo_model.IsErrSubjectNotExist(err))
 }
 
+func TestGetPublicRepositoryBySubject_NoPublicRepo(t *testing.T) {
+	assert.NoError(t, unittest.PrepareTestDatabase())
+	ctx := t.Context()
+
+	// Create a subject without any public repository
+	subject, err := repo_model.GetOrCreateSubject(ctx, "Subject Without Public Repo")
+	assert.NoError(t, err)
+	assert.NotNil(t, subject)
+
+	// Try to get a public repository for this subject
+	_, err = repo_model.GetPublicRepositoryBySubject(ctx, "Subject Without Public Repo")
+	assert.Error(t, err)
+	assert.True(t, repo_model.IsErrRepoWithSubjectNotExist(err))
+}
+
 func TestGetPublicRepositoryBySubject_PrefersRootRepo(t *testing.T) {
 	assert.NoError(t, unittest.PrepareTestDatabase())
 	ctx := t.Context()

--- a/services/context/repo.go
+++ b/services/context/repo.go
@@ -1161,7 +1161,7 @@ func RepoAssignmentBySubject(ctx *Context) {
 	// Find repository by subject name (prioritizes root repositories)
 	repo, err := repo_model.GetPublicRepositoryBySubject(ctx, subjectName)
 	if err != nil {
-		if repo_model.IsErrRepoNotExist(err) || repo_model.IsErrSubjectNotExist(err) {
+		if repo_model.IsErrRepoWithSubjectNotExist(err) || repo_model.IsErrSubjectNotExist(err) {
 			ctx.NotFound(err)
 		} else {
 			ctx.ServerError("GetPublicRepositoryBySubject", err)


### PR DESCRIPTION
* Create new error type ErrRepoWithSubjectNotExist to distinguish between subject lookup failures and repository-by-subject lookup failures.