### PR TITLE
Optimise hyphen collapsing in GenerateRepoNameFromSubject

### DIFF
--- a/models/repo/repo.go
+++ b/models/repo/repo.go
@@ -66,6 +66,7 @@ func (err ErrRepoIsArchived) Error() string {
 type globalVarsStruct struct {
 	validRepoNamePattern     *regexp.Regexp
 	invalidRepoNamePattern   *regexp.Regexp
+	multiHyphenRegex         *regexp.Regexp
 	reservedRepoNames        []string
 	reservedRepoNamePatterns []string
 }
@@ -74,6 +75,7 @@ var globalVars = sync.OnceValue(func() *globalVarsStruct {
 	return &globalVarsStruct{
 		validRepoNamePattern:     regexp.MustCompile(`^[-.\w]+$`),
 		invalidRepoNamePattern:   regexp.MustCompile(`[.]{2,}`),
+		multiHyphenRegex:         regexp.MustCompile(`-{2,}`),
 		reservedRepoNames:        []string{".", "..", "-"},
 		reservedRepoNamePatterns: []string{"*.wiki", "*.git", "*.rss", "*.atom"},
 	}
@@ -1204,9 +1206,7 @@ func GenerateRepoNameFromSubject(subject string) string {
 	name = strings.Trim(name, "-_")
 
 	// Collapse multiple consecutive hyphens
-	for strings.Contains(name, "--") {
-		name = strings.ReplaceAll(name, "--", "-")
-	}
+	name = globalVars().multiHyphenRegex.ReplaceAllString(name, "-")
 
 	// Ensure it's not empty and not too long
 	if name == "" {


### PR DESCRIPTION
* Replace inefficient O(n*m) for loop with O(n) regex-based replacement for collapsing consecutive hyphens.
* The new implementation uses a pre-compiled regex pattern (-{2,}) stored in globalVars, matching the existing pattern for other regex operations in the file. This reduces time complexity from O(n*m) to O(n) where n is string length and m is the number of consecutive hyphens.